### PR TITLE
[Enhancement] Add --project-root option and fix model path resolution

### DIFF
--- a/metricflow/cli/cli_context.py
+++ b/metricflow/cli/cli_context.py
@@ -49,6 +49,7 @@ class CLIContext:
         self._config_handler: Optional[YamlFileHandler] = None
         self._datasource: Optional[str] = None
         self._config_path: Optional[str] = None
+        self._project_root: Optional[str] = None
         self._configure_logging()
 
     def set_config_path(self, config_path: str) -> None:
@@ -57,6 +58,14 @@ class CLIContext:
         This must be called before accessing any config-dependent properties.
         """
         self._config_path = config_path
+        self._config_handler = None  # Reset to force recreation
+
+    def set_project_root(self, project_root: str) -> None:
+        """Set the Datus project root directory.
+
+        This must be called before accessing any config-dependent properties.
+        """
+        self._project_root = project_root
         self._config_handler = None  # Reset to force recreation
 
     def set_datasource(self, datasource: str) -> None:
@@ -76,7 +85,9 @@ class CLIContext:
         """
         if self._config_handler is None:
             if self._datasource:
-                self._config_handler = DatusConfigHandler(datasource=self._datasource, config_path=self._config_path)
+                self._config_handler = DatusConfigHandler(
+                    datasource=self._datasource, config_path=self._config_path, project_root=self._project_root
+                )
             else:
                 self._config_handler = ConfigHandler()
         return self._config_handler

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -74,14 +74,19 @@ _telemetry_reporter.add_python_log_handler()
 @click.option("-v", "--verbose", is_flag=True)
 @click.option("--datasource", help="Datus datasource to use for configuration")
 @click.option("--config", help="Path to Datus agent configuration file")
+@click.option("--project-root", help="Datus project root directory (default: current directory)")
 @pass_config
 @log_call(module_name=__name__, telemetry_reporter=_telemetry_reporter)
-def cli(cfg: CLIContext, verbose: bool, datasource: Optional[str], config: Optional[str]) -> None:  # noqa: D
+def cli(
+    cfg: CLIContext, verbose: bool, datasource: Optional[str], config: Optional[str], project_root: Optional[str]
+) -> None:  # noqa: D
     cfg.verbose = verbose
 
     # Set config path and datasource if provided
     if config:
         cfg.set_config_path(config)
+    if project_root:
+        cfg.set_project_root(project_root)
     if datasource:
         cfg.set_datasource(datasource)
 

--- a/metricflow/configuration/datus_config_handler.py
+++ b/metricflow/configuration/datus_config_handler.py
@@ -25,10 +25,11 @@ from metricflow.configuration.yaml_handler import YamlFileHandler
 class DatusConfigHandler(YamlFileHandler):
     """Config handler that reads from Datus agent.yml configuration."""
 
-    def __init__(self, datasource: str, config_path: Optional[str] = None) -> None:
+    def __init__(self, datasource: str, config_path: Optional[str] = None, project_root: Optional[str] = None) -> None:
         """Initialize DatusConfigHandler with datasource and optional config path."""
         self.datasource = datasource
         self.config_path = config_path
+        self.project_root = project_root
         self.datus_config = self._load_datus_config()
         self.db_config = self._get_datasource_db_config()
 
@@ -112,20 +113,18 @@ class DatusConfigHandler(YamlFileHandler):
         """Get semantic models path for the datasource.
 
         Returns:
-            Path: {datus_home}/semantic_models/{datasource}
+            Path: {project_root}/subject/semantic_models/{datasource}
 
-        The datus_home is determined from agent.home config.
-        If not configured, defaults to ~/.datus
+        The project_root is determined by (in priority order):
+        1. Explicit project_root parameter
+        2. Current working directory
         """
-        # Get datus home from agent.home config
-        agent_home = self.datus_config.get("agent", {}).get("home", "")
-        if agent_home:
-            datus_home = pathlib.Path(agent_home).expanduser().resolve()
+        if self.project_root:
+            root = pathlib.Path(self.project_root).expanduser().resolve()
         else:
-            datus_home = pathlib.Path.home() / ".datus"
+            root = pathlib.Path.cwd()
 
-        # Construct semantic models path: {datus_home}/semantic_models/{datasource}
-        model_path = datus_home / "semantic_models" / self.datasource
+        model_path = root / "subject" / "semantic_models" / self.datasource
 
         return str(model_path)
 

--- a/metricflow/model/parsing/dir_to_model.py
+++ b/metricflow/model/parsing/dir_to_model.py
@@ -3,7 +3,6 @@ import os
 from dataclasses import dataclass
 from string import Template
 import traceback
-import git
 from typing import Optional, Dict, List, Union, Type
 
 from jsonschema import exceptions
@@ -69,10 +68,6 @@ def collect_yaml_config_file_paths(directory: str) -> List[str]:
         - In hidden directories (i.e. directories starting with '.')
         - Hidden files (i.e. files starting with '.')
         - Non YAML files
-        - Ignored by the repo's .gitignore file (if a repo is detected)
-
-    NOTE: We ignore files ignored by .gitignore because an issue cropped up wherein
-    sometimes dependencies of projects include YAML files in their package.
     """
     config_file_paths: List[str] = []
     for root, dirs, files in os.walk(directory):
@@ -88,18 +83,6 @@ def collect_yaml_config_file_paths(directory: str) -> List[str]:
 
             file_path = os.path.join(root, file)
             config_file_paths.append(file_path)
-
-    if not config_file_paths:
-        return config_file_paths
-
-    try:
-        repo = git.Repo(directory, search_parent_directories=True)
-        # repo.ignored returns a list of file paths which are the file paths
-        # that should be ignored as a subset of the handed in file paths
-        ignored_files = repo.ignored(config_file_paths)
-        config_file_paths = list(set(config_file_paths) - set(ignored_files))
-    except git.exc.InvalidGitRepositoryError:
-        pass
 
     return config_file_paths
 


### PR DESCRIPTION
## Why

MetricFlow was reading semantic model YAMLs from `~/.datus/semantic_models/{datasource}`, but Datus agent writes them to `{project_root}/subject/semantic_models/{datasource}`. This path mismatch caused `mf list-metrics` to always return 0 metrics. Additionally, the `.gitignore` filtering in the YAML loader silently excluded valid model files when the `subject/` directory was gitignored.

## Solution

- **`--project-root` CLI option**: Added to the `mf` CLI group. Defaults to CWD when not specified. Passed through `CLIContext` → `DatusConfigHandler`, which now constructs model path as `{project_root}/subject/semantic_models/{datasource}`.
- **Removed `.gitignore` filtering**: `collect_yaml_config_file_paths()` in `dir_to_model.py` no longer uses `git.Repo.ignored()` to filter out YAML files. The user explicitly specifies the model directory, so gitignore rules should not apply.

## Test Cases

No new integration tests — changes are in CLI plumbing and config resolution. Verified manually with `mf --datasource game3 list-metrics` against a real Datus project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--project-root` CLI option to enable users to specify a custom root directory for project configuration and model discovery, supporting more flexible project layouts.

* **Configuration Changes**
  * Semantic model paths now resolve relative to the specified project root instead of system defaults, with automatic fallback to the current working directory when not specified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->