### PR TITLE
[Tool] Release datus-metricflow 0.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datus-metricflow"
-version = "0.2.1"
+version = "0.2.2"
 description = "Simplified MetricFlow integration for Datus Agent - One-command setup for semantic metrics"
 authors = ["Datus.ai <support@datus.ai>", "Transform <hello@transformdata.io>"]
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
## Why

Publish the latest MetricFlow upstream changes, including the Greenplum/Postgres `sslmode` propagation fix, as a PyPI package.

## Solution

- bump `datus-metricflow` to `0.2.2`

## Published Package

- https://pypi.org/project/datus-metricflow/0.2.2/

## Validation

- `uv build --out-dir dist-release`
- `uvx twine check dist-release/*`
- PyPI JSON verification for wheel and sdist
- PyPI wheel download verification for `datus-metricflow==0.2.2`

Note: full dependency install on local macOS arm64 is blocked by `snowflake-connector-python` native build; package publication and metadata were verified from PyPI.
