### PR TITLE
[Enhancement] Bump datus-metricflow to 0.2.3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datus-metricflow"
-version = "0.2.2"
+version = "0.2.3"
 description = "Simplified MetricFlow integration for Datus Agent - One-command setup for semantic metrics"
 authors = ["Datus.ai <support@datus.ai>", "Transform <hello@transformdata.io>"]
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
## Why

PR #34 changed the package metadata so Snowflake, BigQuery, and Databricks connectors are installed only through explicit extras. The package version must be bumped before publishing because `0.2.2` already exists.

## Solution

Bump `datus-metricflow` from `0.2.2` to `0.2.3`.

## Test Cases

- `poetry check`
- `poetry build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Package version updated to 0.2.3

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Datus-ai/metricflow/pull/35?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->