### PR TITLE
[BugFix] Release model validator process pools

### DIFF
--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -77,7 +77,7 @@ class ModelValidator:
             raise ValueError("ModelValidator 'rules' must be a sequence with at least one ModelValidationRule.")
 
         self._rules = rules
-        self._executor = ProcessPoolExecutor(max_workers=max_workers)
+        self._max_workers = max_workers
 
     def validate_model(self, model: UserConfiguredModel) -> ModelBuildResult:
         """Validate a model according to configured rules."""
@@ -85,14 +85,15 @@ class ModelValidator:
 
         results: List[ModelValidationResults] = []
 
-        futures = [
-            self._executor.submit(validation_rule.validate_model_serialized_for_multiprocessing, serialized_model)
-            for validation_rule in self._rules
-        ]
-        for future in as_completed(futures):
-            res = future.result()
-            result = ModelValidationResults.parse_raw(res)
-            results.append(result)
+        with ProcessPoolExecutor(max_workers=self._max_workers) as executor:
+            futures = [
+                executor.submit(validation_rule.validate_model_serialized_for_multiprocessing, serialized_model)
+                for validation_rule in self._rules
+            ]
+            for future in as_completed(futures):
+                res = future.result()
+                result = ModelValidationResults.parse_raw(res)
+                results.append(result)
 
         return ModelBuildResult(model=model, issues=ModelValidationResults.merge(results))
 

--- a/metricflow/test/model/validations/test_configurable_rules.py
+++ b/metricflow/test/model/validations/test_configurable_rules.py
@@ -1,9 +1,12 @@
 import pytest
+from typing import Any, Callable
 
 from metricflow.dataset.dataset import DataSet
 from metricflow.model.model_validator import ModelValidator
+from metricflow.model.validations.non_empty import NonEmptyRule
 from metricflow.model.validations.materializations import ValidMaterializationRule
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
+from metricflow.model import model_validator as model_validator_module
 from metricflow.test.model.validations.helpers import materialization_with_guaranteed_meta
 from metricflow.test.test_utils import model_with_materialization
 
@@ -41,3 +44,46 @@ def test_cant_configure_model_validator_without_rules() -> None:  # noqa: D
 
     with pytest.raises(ValueError):
         ModelValidator(rules=None)  # type: ignore
+
+
+def test_model_validator_releases_process_pool(
+    simple_model__with_primary_transforms: UserConfiguredModel,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    class ImmediateFuture:
+        def __init__(self, value: str) -> None:
+            self._value = value
+
+        def result(self) -> str:
+            return self._value
+
+    class RecordingExecutor:
+        instances: list["RecordingExecutor"] = []
+
+        def __init__(self, max_workers: int) -> None:
+            self.max_workers = max_workers
+            self.entered = False
+            self.exited = False
+            RecordingExecutor.instances.append(self)
+
+        def __enter__(self) -> "RecordingExecutor":
+            self.entered = True
+            return self
+
+        def __exit__(self, exc_type: object, exc_value: object, traceback: object) -> None:
+            self.exited = True
+
+        def submit(self, fn: Callable[..., str], *args: Any) -> ImmediateFuture:
+            return ImmediateFuture(fn(*args))
+
+    monkeypatch.setattr(model_validator_module, "ProcessPoolExecutor", RecordingExecutor)
+    monkeypatch.setattr(model_validator_module, "as_completed", lambda futures: futures)
+
+    result = ModelValidator(rules=[NonEmptyRule()], max_workers=7).validate_model(simple_model__with_primary_transforms)
+
+    assert result.issues.all_issues == ()
+    assert len(RecordingExecutor.instances) == 1
+    executor = RecordingExecutor.instances[0]
+    assert executor.max_workers == 7
+    assert executor.entered is True
+    assert executor.exited is True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "datus-metricflow"
-version = "0.2.5"
+version = "0.2.6"
 description = "Simplified MetricFlow integration for Datus Agent - One-command setup for semantic metrics"
 authors = ["Datus.ai <support@datus.ai>", "Transform <hello@transformdata.io>"]
 license = "AGPL-3.0-or-later"


### PR DESCRIPTION
## Summary
- create `ProcessPoolExecutor` only for the duration of `ModelValidator.validate_model()`
- remove the persistent executor from `ModelValidator` instances so validation workers are shut down after every validation run
- add regression coverage that verifies the executor context exits
- bump `datus-metricflow` to `0.2.6` for release

## Validation
- `poetry run pytest metricflow/test/model/validations/test_configurable_rules.py -q`
- `poetry run pytest metricflow/test/model/validations -q`
- `poetry check`
- `poetry build`
- `git diff --check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release v0.2.6

* **Performance**
  * Optimized model validation to improve resource efficiency and ensure proper cleanup of processing resources after each validation run.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->