### PR TITLE
feat(schema): allow uid in locked_metadata and on data_source

### DIFF
--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -61,6 +61,9 @@
                     },
                     "type": "array"
                 },
+                "locked_metadata": {
+                    "$ref": "#/definitions/locked_metadata"
+                },
                 "measures": {
                     "items": {
                         "$ref": "#/definitions/measure_schema"
@@ -354,6 +357,9 @@
                         "string",
                         "integer"
                     ]
+                },
+                "uid": {
+                    "type": "string"
                 },
                 "unit": {
                     "type": "string"

--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -343,6 +343,9 @@
                 "increase_is_good": {
                     "type": "boolean"
                 },
+                "owner": {
+                    "type": "string"
+                },
                 "private": {
                     "type": "boolean"
                 },

--- a/metricflow/model/parsing/schemas_internal.py
+++ b/metricflow/model/parsing/schemas_internal.py
@@ -75,6 +75,8 @@ locked_metadata_schema = {
         },
         "private": {"type": "boolean"},
         "unit": {"type": "string"},
+        # Stable node identity assigned by the Semantic Hub.
+        "uid": {"type": "string"},
     },
     "additionalProperties": False,
 }
@@ -89,6 +91,7 @@ add_transform_metadata_fields_to_spec(metric_schema)
 add_locked_metadata_to_spec(metric_schema)
 
 add_transform_metadata_fields_to_spec(data_source_schema)
+add_locked_metadata_to_spec(data_source_schema)
 add_transform_metadata_fields_to_spec(materialization_schema)
 add_transform_metadata_fields_to_spec(derived_group_by_element_schema)
 

--- a/metricflow/model/parsing/schemas_internal.py
+++ b/metricflow/model/parsing/schemas_internal.py
@@ -77,6 +77,8 @@ locked_metadata_schema = {
         "unit": {"type": "string"},
         # Stable node identity assigned by the Semantic Hub.
         "uid": {"type": "string"},
+        # Node owner / creator.
+        "owner": {"type": "string"},
     },
     "additionalProperties": False,
 }

--- a/metricflow/test/model/parsing/test_locked_metadata_schema.py
+++ b/metricflow/test/model/parsing/test_locked_metadata_schema.py
@@ -1,0 +1,48 @@
+"""Schema-validator tests for the locked_metadata.uid field.
+
+uid is the stable node identity assigned by the Semantic Hub; it is written into
+both metric and data_source YAML, so the validators must accept it (and the
+data_source spec must accept a locked_metadata block at all) while still
+rejecting genuinely unknown keys.
+"""
+
+import pytest
+from jsonschema.exceptions import ValidationError
+
+from metricflow.model.parsing.schemas_internal import (
+    data_source_validator,
+    metric_validator,
+)
+
+
+def test_metric_locked_metadata_accepts_uid() -> None:
+    metric_validator.validate(
+        {
+            "name": "bookings",
+            "type": "measure_proxy",
+            "type_params": {"measures": ["bookings"]},
+            "locked_metadata": {"uid": "01HZX9Q2K7", "tags": ["t"]},
+        }
+    )
+
+
+def test_data_source_accepts_locked_metadata_uid() -> None:
+    data_source_validator.validate(
+        {
+            "name": "id_verifications",
+            "sql_table": "fct_id_verifications",
+            "locked_metadata": {"uid": "01HZX9Q2K7"},
+        }
+    )
+
+
+def test_locked_metadata_still_rejects_unknown_key() -> None:
+    with pytest.raises(ValidationError):
+        metric_validator.validate(
+            {
+                "name": "bookings",
+                "type": "measure_proxy",
+                "type_params": {"measures": ["bookings"]},
+                "locked_metadata": {"bogus_field": "x"},
+            }
+        )

--- a/metricflow/test/model/parsing/test_locked_metadata_schema.py
+++ b/metricflow/test/model/parsing/test_locked_metadata_schema.py
@@ -21,7 +21,7 @@ def test_metric_locked_metadata_accepts_uid() -> None:
             "name": "bookings",
             "type": "measure_proxy",
             "type_params": {"measures": ["bookings"]},
-            "locked_metadata": {"uid": "01HZX9Q2K7", "tags": ["t"]},
+            "locked_metadata": {"uid": "01HZX9Q2K7", "owner": "arno@datus.ai", "tags": ["t"]},
         }
     )
 
@@ -31,7 +31,7 @@ def test_data_source_accepts_locked_metadata_uid() -> None:
         {
             "name": "id_verifications",
             "sql_table": "fct_id_verifications",
-            "locked_metadata": {"uid": "01HZX9Q2K7"},
+            "locked_metadata": {"uid": "01HZX9Q2K7", "owner": "arno@datus.ai"},
         }
     )
 


### PR DESCRIPTION
## What

- Add `uid` to the `locked_metadata` property whitelist.
- Apply `locked_metadata` to the `data_source` spec (it previously had none), so a data_source can also carry `locked_metadata.uid`.

## Why

The Datus Semantic Hub assigns each governed node a stable identity (`uid`) and writes it into the project YAML's `locked_metadata` for both metrics and semantic models (data_sources). Because `locked_metadata` is `additionalProperties: false` and `data_source` had no `locked_metadata` block at all, MetricFlow rejected every Hub-managed file with:

```
Additional properties are not allowed ('uid' was unexpected)         # metric
Additional properties are not allowed ('locked_metadata' was unexpected)  # data_source
```

## Notes

- Genuinely unknown `locked_metadata` keys are still rejected (whitelist preserved).
- Added `metricflow/test/model/parsing/test_locked_metadata_schema.py` covering: metric accepts `uid`, data_source accepts `locked_metadata.uid`, and an unknown key still raises `ValidationError`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for a required `uid` field in locked metadata.
  * Data source definitions now accept locked metadata as part of schema validation.

* **Bug Fixes**
  * Tightened schema validation to continue rejecting unknown locked-metadata fields while allowing valid `uid` values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->