### PR TITLE
[BugFix] Support runtime DB context in MetricFlow clients

### DIFF
--- a/metricflow/configuration/datus_config_handler.py
+++ b/metricflow/configuration/datus_config_handler.py
@@ -181,6 +181,8 @@ class DatusConfigHandler(YamlFileHandler):
             return self._resolve_env_vars(self.db_config.get("sslmode", ""))
 
         if key == CONFIG_DWH_DB:
+            database = self.db_config.get("database") or self.db_config.get("database_name", "")
+            catalog = self.db_config.get("catalog") or self.db_config.get("catalog_name", "")
             # Special handling for file-based databases
             if db_type in ("sqlite", "duckdb"):
                 uri = self._resolve_env_vars(self.db_config.get("uri", ""))
@@ -189,15 +191,17 @@ class DatusConfigHandler(YamlFileHandler):
                     uri = uri[len(f"{db_type}:///") :]
                 return os.path.expanduser(uri)
             elif db_type == "trino":
-                return self._resolve_env_vars(self.db_config.get("catalog") or self.db_config.get("database", ""))
+                return self._resolve_env_vars(catalog or database)
             else:
-                return self._resolve_env_vars(self.db_config.get("database", ""))
+                return self._resolve_env_vars(database)
 
         if key == CONFIG_DWH_SCHEMA:
             # Support both "schema" and "schema_name" field names for compatibility
             schema = (
                 self.db_config.get("schema") or self.db_config.get("db_schema") or self.db_config.get("schema_name")
             )
+            database = self.db_config.get("database") or self.db_config.get("database_name", "")
+            catalog = self.db_config.get("catalog") or self.db_config.get("catalog_name", "")
             if schema:
                 return self._resolve_env_vars(schema)
             # Default schemas for different DB types
@@ -206,10 +210,10 @@ class DatusConfigHandler(YamlFileHandler):
             elif db_type == "sqlite":
                 return "default"
             elif db_type in ("mysql", "starrocks", "clickhouse"):
-                return self._resolve_env_vars(self.db_config.get("database", ""))
+                return self._resolve_env_vars(database)
             elif db_type == "trino":
-                if self.db_config.get("catalog") and self.db_config.get("database"):
-                    return self._resolve_env_vars(self.db_config.get("database", ""))
+                if catalog and database:
+                    return self._resolve_env_vars(database)
                 return "default"
             elif db_type in ("postgres", "postgresql", "greenplum"):
                 return "public"

--- a/metricflow/configuration/datus_config_handler.py
+++ b/metricflow/configuration/datus_config_handler.py
@@ -188,26 +188,28 @@ class DatusConfigHandler(YamlFileHandler):
                 if uri.startswith(f"{db_type}:///"):
                     uri = uri[len(f"{db_type}:///") :]
                 return os.path.expanduser(uri)
+            elif db_type == "trino":
+                return self._resolve_env_vars(self.db_config.get("catalog") or self.db_config.get("database", ""))
             else:
                 return self._resolve_env_vars(self.db_config.get("database", ""))
 
         if key == CONFIG_DWH_SCHEMA:
             # Support both "schema" and "schema_name" field names for compatibility
-            schema = self.db_config.get("schema") or self.db_config.get("schema_name")
+            schema = (
+                self.db_config.get("schema") or self.db_config.get("db_schema") or self.db_config.get("schema_name")
+            )
             if schema:
                 return self._resolve_env_vars(schema)
             # Default schemas for different DB types
             if db_type == "duckdb":
                 return "main"
-            elif db_type in ("sqlite", "mysql"):
+            elif db_type == "sqlite":
                 return "default"
-            elif db_type == "starrocks":
-                # For StarRocks, use database as schema since it doesn't have schema concept
-                return self._resolve_env_vars(self.db_config.get("database", ""))
-            elif db_type == "clickhouse":
-                # For ClickHouse, schema == database
+            elif db_type in ("mysql", "starrocks", "clickhouse"):
                 return self._resolve_env_vars(self.db_config.get("database", ""))
             elif db_type == "trino":
+                if self.db_config.get("catalog") and self.db_config.get("database"):
+                    return self._resolve_env_vars(self.db_config.get("database", ""))
                 return "default"
             elif db_type in ("postgres", "postgresql", "greenplum"):
                 return "public"

--- a/metricflow/configuration/dict_config_handler.py
+++ b/metricflow/configuration/dict_config_handler.py
@@ -48,6 +48,8 @@ DEFAULT_SCHEMA_MAPPING = {
     "greenplum": "public",
 }
 
+SCHEMA_EQUALS_DATABASE_TYPES = {"mysql", "starrocks", "clickhouse"}
+
 
 def build_config_dict_from_db_params(
     db_type: str,
@@ -67,6 +69,7 @@ def build_config_dict_from_db_params(
     private_key: str = "",
     private_key_file: str = "",
     private_key_file_pwd: str = "",
+    catalog: str = "",
 ) -> Dict[str, str]:
     """Build a MetricFlow config dict from database connection parameters.
 
@@ -88,22 +91,24 @@ def build_config_dict_from_db_params(
     result[CONFIG_DWH_PASSWORD] = password
     result[CONFIG_DWH_SSLMODE] = sslmode
 
-    # Database — file-based DBs use uri
+    # Database — file-based DBs use uri; Trino uses catalog as the URL database segment.
     if db_type_lower in ("sqlite", "duckdb") and uri:
         db_path = uri
         prefix = f"{db_type_lower}:///"
         if db_path.startswith(prefix):
             db_path = db_path[len(prefix) :]
         result[CONFIG_DWH_DB] = os.path.expanduser(db_path)
+    elif db_type_lower == "trino" and catalog:
+        result[CONFIG_DWH_DB] = catalog
     else:
         result[CONFIG_DWH_DB] = database
 
     # Schema — with defaults per DB type
     if schema:
         result[CONFIG_DWH_SCHEMA] = schema
-    elif db_type_lower == "starrocks":
+    elif db_type_lower == "trino" and catalog and database:
         result[CONFIG_DWH_SCHEMA] = database
-    elif db_type_lower == "clickhouse":
+    elif db_type_lower in SCHEMA_EQUALS_DATABASE_TYPES and database:
         result[CONFIG_DWH_SCHEMA] = database
     elif db_type_lower == "trino":
         result[CONFIG_DWH_SCHEMA] = "default"
@@ -141,9 +146,17 @@ def _string_config_value(value: Any) -> str:
 
 def build_config_dict_from_datus_datasource(db_config: Mapping[str, Any], model_path: str = "") -> Dict[str, str]:
     """Build a MetricFlow config dict from a raw Datus datasource config."""
+    database = db_config.get("database")
+    if database is None or database == "":
+        database = db_config.get("database_name", "")
+
     schema = db_config.get("schema")
     if schema is None or schema == "":
-        schema = db_config.get("schema_name", "")
+        schema = db_config.get("db_schema") or db_config.get("schema_name", "")
+
+    catalog = db_config.get("catalog")
+    if catalog is None or catalog == "":
+        catalog = db_config.get("catalog_name", "")
 
     return build_config_dict_from_db_params(
         db_type=_string_config_value(db_config.get("type")),
@@ -151,7 +164,7 @@ def build_config_dict_from_datus_datasource(db_config: Mapping[str, Any], model_
         port=_string_config_value(db_config.get("port")),
         username=_string_config_value(db_config.get("username")),
         password=_string_config_value(db_config.get("password")),
-        database=_string_config_value(db_config.get("database")),
+        database=_string_config_value(database),
         schema=_string_config_value(schema),
         uri=_string_config_value(db_config.get("uri")),
         warehouse=_string_config_value(db_config.get("warehouse")),
@@ -163,6 +176,7 @@ def build_config_dict_from_datus_datasource(db_config: Mapping[str, Any], model_
         private_key=_string_config_value(db_config.get("private_key")),
         private_key_file=_string_config_value(db_config.get("private_key_file")),
         private_key_file_pwd=_string_config_value(db_config.get("private_key_file_pwd")),
+        catalog=_string_config_value(catalog),
     )
 
 

--- a/metricflow/sql_clients/sql_utils.py
+++ b/metricflow/sql_clients/sql_utils.py
@@ -15,6 +15,7 @@ from metricflow.configuration.constants import (
     CONFIG_DWH_PRIVATE_KEY_FILE,
     CONFIG_DWH_PRIVATE_KEY_FILE_PWD,
     CONFIG_DWH_ROLE,
+    CONFIG_DWH_SCHEMA,
     CONFIG_DWH_SSLMODE,
     CONFIG_DWH_USER,
     CONFIG_DWH_PASSWORD,
@@ -195,9 +196,11 @@ def make_sql_client_from_config(handler: YamlFileHandler) -> AsyncSqlClient:
         username = not_empty(handler.get_value(CONFIG_DWH_USER), "username", url)
         password = handler.get_value(CONFIG_DWH_PASSWORD) or ""
         database = handler.get_value(CONFIG_DWH_DB) or ""
+        schema = handler.get_value(CONFIG_DWH_SCHEMA) or ""
 
         if database:
-            trino_url = f"trino://{username}@{host}:{port}/{database}"
+            trino_database = f"{database}/{schema}" if schema else database
+            trino_url = f"trino://{username}@{host}:{port}/{trino_database}"
         else:
             trino_url = f"trino://{username}@{host}:{port}"
         return TrinoSqlClient.from_connection_details(trino_url, password)

--- a/metricflow/sql_clients/trino.py
+++ b/metricflow/sql_clients/trino.py
@@ -49,7 +49,7 @@ class TrinoEngineAttributes:
 class TrinoSqlClient(SqlAlchemySqlClient):
     """Implements Trino.
 
-    Uses the trino:// SQLAlchemy driver. URL format: trino://user@host:port/catalog
+    Uses the trino:// SQLAlchemy driver. URL format: trino://user@host:port/catalog[/schema]
     """
 
     @staticmethod
@@ -79,7 +79,7 @@ class TrinoSqlClient(SqlAlchemySqlClient):
         host: str,
         password: str = "",
     ) -> None:
-        # Trino URL format: trino://user:password@host:port/catalog
+        # Trino URL format: trino://user:password@host:port/catalog[/schema]
         connect_url = sqlalchemy.engine.url.URL.create(
             drivername="trino",
             username=username,

--- a/metricflow/test/integration/test_trino_integration.py
+++ b/metricflow/test/integration/test_trino_integration.py
@@ -118,8 +118,25 @@ class TestTrinoClientFromConfig:
             assert "trino" in url
             assert "trino-host" in url
             assert "8090" in url
-            assert "memory" in url
+            assert "memory/default" in url
             assert password == ""
+
+    def test_make_sql_client_from_config_includes_trino_schema(self) -> None:
+        config_dict = build_config_dict_from_db_params(
+            db_type="trino",
+            host="trino-host",
+            port="8090",
+            username="trino",
+            password="",
+            database="memory",
+            schema="analytics",
+        )
+        handler = DictConfigHandler(config_dict)
+
+        with patch.object(TrinoSqlClient, "from_connection_details", return_value=MagicMock()) as mock_factory:
+            make_sql_client_from_config(handler)
+            url = mock_factory.call_args[0][0]
+            assert "memory/analytics" in url
 
 
 class TestTrinoSqlRendering:

--- a/metricflow/test/test_dict_config_handler.py
+++ b/metricflow/test/test_dict_config_handler.py
@@ -44,7 +44,7 @@ class TestBuildConfigDictFromDbParams:
         assert result[CONFIG_DWH_USER] == "root"
         assert result[CONFIG_DWH_PASSWORD] == "secret"
         assert result[CONFIG_DWH_DB] == "mydb"
-        assert result[CONFIG_DWH_SCHEMA] == "default"
+        assert result[CONFIG_DWH_SCHEMA] == "mydb"
 
     def test_starrocks(self):
         result = build_config_dict_from_db_params(
@@ -176,9 +176,14 @@ class TestBuildConfigDictFromDbParams:
     def test_explicit_schema_overrides_default(self):
         result = build_config_dict_from_db_params(
             db_type="mysql",
+            database="mydb",
             schema="custom_schema",
         )
         assert result[CONFIG_DWH_SCHEMA] == "custom_schema"
+
+    def test_mysql_without_database_keeps_legacy_default_schema(self):
+        result = build_config_dict_from_db_params(db_type="mysql")
+        assert result[CONFIG_DWH_SCHEMA] == "default"
 
     def test_unknown_db_type_passes_through(self):
         result = build_config_dict_from_db_params(db_type="mssql")
@@ -193,6 +198,15 @@ class TestBuildConfigDictFromDbParams:
             database="ch_db",
         )
         assert result[CONFIG_DWH_DIALECT] == "clickhouse"
+
+    def test_trino_catalog_maps_to_dwh_database_and_database_maps_to_schema(self):
+        result = build_config_dict_from_db_params(
+            db_type="trino",
+            catalog="hive",
+            database="college_exam",
+        )
+        assert result[CONFIG_DWH_DB] == "hive"
+        assert result[CONFIG_DWH_SCHEMA] == "college_exam"
 
 
 class TestBuildConfigDictFromDatusDatasource:
@@ -248,6 +262,35 @@ class TestBuildConfigDictFromDatusDatasource:
         assert result[CONFIG_DWH_SSLMODE] == "require"
         assert result[CONFIG_MODEL_PATH] == "/tmp/models"
 
+    def test_builds_config_from_runtime_trino_context(self):
+        result = build_config_dict_from_datus_datasource(
+            {
+                "type": "trino",
+                "host": "trino-host",
+                "port": 8080,
+                "username": "trino",
+                "catalog": "hive",
+                "database": "college_exam",
+            }
+        )
+
+        assert result[CONFIG_DWH_DIALECT] == "trino"
+        assert result[CONFIG_DWH_DB] == "hive"
+        assert result[CONFIG_DWH_SCHEMA] == "college_exam"
+
+    def test_builds_config_from_runtime_schema_alias(self):
+        result = build_config_dict_from_datus_datasource(
+            {
+                "type": "mysql",
+                "host": "mysql-host",
+                "database": "college_exam",
+                "db_schema": "semantic_schema",
+            }
+        )
+
+        assert result[CONFIG_DWH_DB] == "college_exam"
+        assert result[CONFIG_DWH_SCHEMA] == "semantic_schema"
+
 
 class TestDictConfigHandler:
     """Tests for DictConfigHandler."""
@@ -290,7 +333,7 @@ class TestDictConfigHandler:
         assert handler.get_value(CONFIG_DWH_USER) == "user1"
         assert handler.get_value(CONFIG_DWH_PASSWORD) == "pass1"
         assert handler.get_value(CONFIG_DWH_DB) == "testdb"
-        assert handler.get_value(CONFIG_DWH_SCHEMA) == "default"
+        assert handler.get_value(CONFIG_DWH_SCHEMA) == "testdb"
         assert handler.get_value(CONFIG_MODEL_PATH) == "/models"
 
 

--- a/metricflow/test/test_dict_config_handler.py
+++ b/metricflow/test/test_dict_config_handler.py
@@ -338,6 +338,34 @@ class TestDictConfigHandler:
 
 
 class TestDatusConfigHandler:
+    def test_get_value_resolves_database_and_catalog_aliases(self, tmp_path):
+        config_path = tmp_path / "agent.yml"
+        config_path.write_text(
+            """
+agent:
+  services:
+    datasources:
+      starrocks:
+        type: starrocks
+        host: sr-host
+        database_name: runtime_db
+      trino:
+        type: trino
+        host: trino-host
+        catalog_name: tpch
+        database_name: tiny
+""",
+            encoding="utf-8",
+        )
+
+        starrocks_handler = DatusConfigHandler("starrocks", config_path=str(config_path))
+        assert starrocks_handler.get_value(CONFIG_DWH_DB) == "runtime_db"
+        assert starrocks_handler.get_value(CONFIG_DWH_SCHEMA) == "runtime_db"
+
+        trino_handler = DatusConfigHandler("trino", config_path=str(config_path))
+        assert trino_handler.get_value(CONFIG_DWH_DB) == "tpch"
+        assert trino_handler.get_value(CONFIG_DWH_SCHEMA) == "tiny"
+
     def test_get_value_returns_sslmode_from_datasource_config(self, tmp_path):
         config_path = tmp_path / "agent.yml"
         config_path.write_text(


### PR DESCRIPTION
## Summary
- Accept catalog/database/schema aliases from Datus datasource and dict config inputs.
- Default schema from database for engines whose namespace semantics require it.
- Include Trino schema in client URLs so the session has both catalog and schema.

## Validation
- `/Users/kangxue/work/datus/metricflow-runtime-semantic-db-context/.venv/bin/python -m pytest metricflow/test/test_dict_config_handler.py::TestBuildConfigDictFromDbParams metricflow/test/test_dict_config_handler.py::TestBuildConfigDictFromDatusDatasource metricflow/test/integration/test_trino_integration.py::TestTrinoClientFromConfig -q`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved database setup handling for Trino, including support for catalog and schema in connection settings.
  * Added broader schema field support, so several common schema names are now recognized automatically.

* **Bug Fixes**
  * Fixed schema defaults for multiple databases, including more consistent behavior for DuckDB, SQLite, MySQL, StarRocks, and ClickHouse.
  * Trino connections now include the configured schema when present, helping connect to the correct namespace.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->