### PR TITLE
feat(schema): allow status in locked_metadata

### DIFF
--- a/metricflow/model/parsing/schemas/metricflow.json
+++ b/metricflow/model/parsing/schemas/metricflow.json
@@ -349,6 +349,9 @@
                 "private": {
                     "type": "boolean"
                 },
+                "status": {
+                    "type": "string"
+                },
                 "tags": {
                     "items": {
                         "type": "string"

--- a/metricflow/model/parsing/schemas_internal.py
+++ b/metricflow/model/parsing/schemas_internal.py
@@ -79,6 +79,8 @@ locked_metadata_schema = {
         "uid": {"type": "string"},
         # Node owner / creator.
         "owner": {"type": "string"},
+        # Certification status assigned by the Semantic Hub (e.g. certified/draft).
+        "status": {"type": "string"},
     },
     "additionalProperties": False,
 }

--- a/metricflow/test/model/parsing/test_locked_metadata_schema.py
+++ b/metricflow/test/model/parsing/test_locked_metadata_schema.py
@@ -1,9 +1,8 @@
-"""Schema-validator tests for the locked_metadata.uid field.
+"""Schema-validator tests for the Semantic Hub locked_metadata fields.
 
-uid is the stable node identity assigned by the Semantic Hub; it is written into
-both metric and data_source YAML, so the validators must accept it (and the
-data_source spec must accept a locked_metadata block at all) while still
-rejecting genuinely unknown keys.
+uid/owner/status are stamped by the Semantic Hub into metric and data_source YAML,
+so the validators must accept them (and the data_source spec must accept a
+locked_metadata block at all) while still rejecting genuinely unknown keys.
 """
 
 import pytest
@@ -21,7 +20,12 @@ def test_metric_locked_metadata_accepts_uid() -> None:
             "name": "bookings",
             "type": "measure_proxy",
             "type_params": {"measures": ["bookings"]},
-            "locked_metadata": {"uid": "01HZX9Q2K7", "owner": "arno@datus.ai", "tags": ["t"]},
+            "locked_metadata": {
+                "uid": "01HZX9Q2K7",
+                "owner": "arno@datus.ai",
+                "status": "certified",
+                "tags": ["t"],
+            },
         }
     )
 


### PR DESCRIPTION
## What

Add `status` to the `locked_metadata` whitelist for both the metric and data_source specs.

## Why

The Semantic Hub stamps a certification status (`certified`/`draft`/…) into metric `locked_metadata`, alongside the `uid`/`owner` fields added in #40. Because `locked_metadata` is `additionalProperties: false`, any metric YAML carrying `status` fails validation with:

```
Error: Additional properties are not allowed ('status' was unexpected)
ERROR: in file `.../metric.yml` on line #1 - YAML document did not conform to metric spec.
```

This surfaced in prod as a **400** on `POST /api/v1/internal/hub/metric/dimensions` (MetricFlow client failed to initialize) whenever a certified metric was queried. Model files were unaffected because their `locked_metadata` only carries `uid`/`owner`.

## Changes

- `schemas_internal.py`: add `status: {type: string}` to `locked_metadata_schema`.
- `schemas/metricflow.json`: mirror the same key in the JSON schema.
- `test_locked_metadata_schema.py`: cover `status` in the accept-case; unknown-key rejection unchanged.

Unknown `locked_metadata` keys are still rejected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated metadata validation so a new `status` field is accepted in locked metadata.
  * Existing metadata fields continue to validate correctly, while unknown fields are still rejected.
  * Expanded validation coverage to include the new `status` field and additional accepted metadata values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->