### PR TITLE
Avoid unsafe process pools during model validation

### DIFF
--- a/metricflow/model/model_validator.py
+++ b/metricflow/model/model_validator.py
@@ -1,6 +1,7 @@
 from concurrent.futures import ProcessPoolExecutor, as_completed
 import copy
 import logging
+import multiprocessing
 from typing import List, Sequence
 
 from metricflow.model.objects.user_configured_model import UserConfiguredModel
@@ -85,15 +86,29 @@ class ModelValidator:
 
         results: List[ModelValidationResults] = []
 
-        with ProcessPoolExecutor(max_workers=self._max_workers) as executor:
-            futures = [
-                executor.submit(validation_rule.validate_model_serialized_for_multiprocessing, serialized_model)
+        if self._max_workers == 1:
+            # A single-worker process pool provides no parallelism and can be
+            # unsafe after threaded runtimes such as LanceDB have initialized.
+            # Keep the serialized validation boundary, but execute the rules in
+            # the current process.
+            serialized_results = [
+                validation_rule.validate_model_serialized_for_multiprocessing(serialized_model)
                 for validation_rule in self._rules
             ]
-            for future in as_completed(futures):
-                res = future.result()
-                result = ModelValidationResults.parse_raw(res)
-                results.append(result)
+        else:
+            # Do not inherit the application's global multiprocessing policy.
+            # ``spawn`` starts validators with a clean runtime on macOS, Linux,
+            # and Windows instead of forking live threads and async runtimes.
+            context = multiprocessing.get_context("spawn")
+            with ProcessPoolExecutor(max_workers=self._max_workers, mp_context=context) as executor:
+                futures = [
+                    executor.submit(validation_rule.validate_model_serialized_for_multiprocessing, serialized_model)
+                    for validation_rule in self._rules
+                ]
+                serialized_results = [future.result() for future in as_completed(futures)]
+
+        for serialized_result in serialized_results:
+            results.append(ModelValidationResults.parse_raw(serialized_result))
 
         return ModelBuildResult(model=model, issues=ModelValidationResults.merge(results))
 

--- a/metricflow/model/validations/validator_helpers.py
+++ b/metricflow/model/validations/validator_helpers.py
@@ -363,9 +363,9 @@ class ModelValidationRule(ABC):
     def validate_model_serialized_for_multiprocessing(cls, serialized_model: str) -> str:
         """Validate a model serialized via Pydantic's .model_dump_json() method, and return a list of JSON serialized issues
 
-        This method exists because our validations are forked into parallel processes via
-        multiprocessing.ProcessPoolExecutor, and passing a model or validation results object can result in
-        idiosyncratic behavior and inscrutable errors due to interactions between pickling and pydantic objects.
+        This serialization boundary supports both in-process validation and optional parallel
+        validation via ProcessPoolExecutor. Passing Pydantic objects directly across a process
+        boundary can produce idiosyncratic pickling behavior and inscrutable errors.
         """
         return ModelValidationResults.from_issues_sequence(
             cls.validate_model(UserConfiguredModel.model_validate_json(serialized_model))

--- a/metricflow/test/model/validations/test_configurable_rules.py
+++ b/metricflow/test/model/validations/test_configurable_rules.py
@@ -60,8 +60,9 @@ def test_model_validator_releases_process_pool(
     class RecordingExecutor:
         instances: list["RecordingExecutor"] = []
 
-        def __init__(self, max_workers: int) -> None:
+        def __init__(self, max_workers: int, mp_context: Any) -> None:
             self.max_workers = max_workers
+            self.mp_context = mp_context
             self.entered = False
             self.exited = False
             RecordingExecutor.instances.append(self)
@@ -85,5 +86,28 @@ def test_model_validator_releases_process_pool(
     assert len(RecordingExecutor.instances) == 1
     executor = RecordingExecutor.instances[0]
     assert executor.max_workers == 7
+    assert executor.mp_context.get_start_method() == "spawn"
     assert executor.entered is True
     assert executor.exited is True
+
+
+def test_model_validator_runs_single_worker_in_current_process(
+    simple_model__with_primary_transforms: UserConfiguredModel,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def unexpected_process_pool(*args: Any, **kwargs: Any) -> None:
+        raise AssertionError("single-worker validation should not create a process pool")
+
+    monkeypatch.setattr(model_validator_module, "ProcessPoolExecutor", unexpected_process_pool)
+
+    result = ModelValidator(rules=[NonEmptyRule()], max_workers=1).validate_model(simple_model__with_primary_transforms)
+
+    assert result.issues.all_issues == ()
+
+
+def test_model_validator_runs_parallel_rules_with_spawn(
+    simple_model__with_primary_transforms: UserConfiguredModel,
+) -> None:
+    result = ModelValidator(rules=[NonEmptyRule()], max_workers=2).validate_model(simple_model__with_primary_transforms)
+
+    assert result.issues.all_issues == ()


### PR DESCRIPTION
## Summary

- run single-worker model validation in the current process instead of creating a process pool with no parallel benefit
- use an explicit `spawn` multiprocessing context when parallel validation is requested
- preserve the serialized validation boundary and ensure the process pool is released through its context manager
- add regression coverage for both the single-worker and parallel paths

## Why

`ModelValidator` defaults to one worker but still created a `ProcessPoolExecutor`. On macOS and Linux this could fork a process after threaded runtimes such as LanceDB had initialized, causing LanceDB to reset its async runtime and emit the experimental fork warning. Avoiding the pool for one worker removes the default warning path, while `spawn` gives opt-in parallel validation a clean child runtime on every supported platform.

## Validation

- `84 passed, 2 skipped` in `metricflow/test/model/validations`
- Black 24.4.2
- Flake8
- pre-commit mypy hook
- real Datus OSI validation against the Greenplum configuration with the LanceDB fork warning promoted to an exception


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model validation reliability when running with a single worker.
  * Improved compatibility and stability for parallel model validation.
  * Validation results remain consistent across in-process and parallel execution modes.

* **Tests**
  * Added coverage for single-worker and spawn-based parallel validation scenarios.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->