### PR TITLE
[Feature] Add Apache Doris support

### DIFF
--- a/README-DATUS.md
+++ b/README-DATUS.md
@@ -39,6 +39,9 @@ mf setup
 mf --datasource starrocks list-metrics
 mf --datasource starrocks query --metrics revenue --dimensions metric_time
 mf --datasource starrocks health-checks
+mf --datasource doris list-metrics
+mf --datasource doris query --metrics revenue --dimensions metric_time
+mf --datasource doris health-checks
 ```
 
 ### Traditional Mode (reads from ~/.metricflow/config.yml)
@@ -154,6 +157,7 @@ For detailed MCP server documentation, see [MCP-SERVER.md](MCP-SERVER.md).
 | SQLite | ✅ Full | File-based |
 | MySQL | ✅ Full | Network database |
 | StarRocks | ✅ Full | Uses MySQL protocol |
+| Apache Doris | ✅ Full | Uses MySQL protocol |
 | PostgreSQL | ⚠️ Config only | Client not in this build |
 | Snowflake | ✅ Full | Password or RSA key pair auth; requires Snowflake dependencies |
 | BigQuery | ⚠️ Config only | Client not in this build |

--- a/metricflow/cli/main.py
+++ b/metricflow/cli/main.py
@@ -36,6 +36,7 @@ from metricflow.cli.utils import (
     MF_SNOWFLAKE_KEYS,
     MF_POSTGRESQL_KEYS,
     MF_DATABRICKS_KEYS,
+    MF_DORIS_KEYS,
     MF_STARROCKS_KEYS,
     MF_TRINO_KEYS,
 )
@@ -186,6 +187,7 @@ def setup(cfg: CLIContext, restart: bool, datasource: Optional[str]) -> None:
             SqlDialect.GREENPLUM.value: MF_GREENPLUM_KEYS,
             SqlDialect.CLICKHOUSE.value: MF_CLICKHOUSE_KEYS,
             SqlDialect.STARROCKS.value: MF_STARROCKS_KEYS,
+            SqlDialect.DORIS.value: MF_DORIS_KEYS,
             SqlDialect.TRINO.value: MF_TRINO_KEYS,
             SqlDialect.DUCKDB.value: generate_duckdb_demo_keys(config_dir=cfg.config.dir_path),
             SqlDialect.DATABRICKS.value: MF_DATABRICKS_KEYS,

--- a/metricflow/cli/utils.py
+++ b/metricflow/cli/utils.py
@@ -142,6 +142,16 @@ MF_STARROCKS_KEYS = (
     ConfigKey(key=CONFIG_DWH_DIALECT, value=SqlDialect.STARROCKS.value),
 )
 
+# Doris config keys
+MF_DORIS_KEYS = (
+    ConfigKey(key=CONFIG_DWH_DB),
+    ConfigKey(key=CONFIG_DWH_PASSWORD, comment="Password associated with the provided user (can be empty)"),
+    ConfigKey(key=CONFIG_DWH_USER, comment="Username for the data warehouse"),
+    ConfigKey(key=CONFIG_DWH_PORT),
+    ConfigKey(key=CONFIG_DWH_HOST, comment="Host name"),
+    ConfigKey(key=CONFIG_DWH_DIALECT, value=SqlDialect.DORIS.value),
+)
+
 # Trino config keys
 MF_TRINO_KEYS = (
     ConfigKey(key=CONFIG_DWH_DB, comment="Catalog name"),

--- a/metricflow/configuration/datus_config_handler.py
+++ b/metricflow/configuration/datus_config_handler.py
@@ -154,6 +154,7 @@ class DatusConfigHandler(YamlFileHandler):
                 "greenplum": "greenplum",
                 "mysql": "mysql",
                 "starrocks": "starrocks",
+                "doris": "doris",
                 "clickhouse": "clickhouse",
                 "trino": "trino",
                 "duckdb": "duckdb",
@@ -209,7 +210,7 @@ class DatusConfigHandler(YamlFileHandler):
                 return "main"
             elif db_type == "sqlite":
                 return "default"
-            elif db_type in ("mysql", "starrocks", "clickhouse"):
+            elif db_type in ("mysql", "starrocks", "doris", "clickhouse"):
                 return self._resolve_env_vars(database)
             elif db_type == "trino":
                 if catalog and database:

--- a/metricflow/configuration/dict_config_handler.py
+++ b/metricflow/configuration/dict_config_handler.py
@@ -30,6 +30,7 @@ DIALECT_MAPPING = {
     "greenplum": "greenplum",
     "mysql": "mysql",
     "starrocks": "starrocks",
+    "doris": "doris",
     "clickhouse": "clickhouse",
     "trino": "trino",
     "duckdb": "duckdb",
@@ -48,7 +49,7 @@ DEFAULT_SCHEMA_MAPPING = {
     "greenplum": "public",
 }
 
-SCHEMA_EQUALS_DATABASE_TYPES = {"mysql", "starrocks", "clickhouse"}
+SCHEMA_EQUALS_DATABASE_TYPES = {"mysql", "starrocks", "doris", "clickhouse"}
 
 
 def build_config_dict_from_db_params(

--- a/metricflow/protocols/sql_client.py
+++ b/metricflow/protocols/sql_client.py
@@ -24,6 +24,7 @@ class SqlEngine(Enum):
     GREENPLUM = "Greenplum"
     CLICKHOUSE = "ClickHouse"
     STARROCKS = "StarRocks"
+    DORIS = "Doris"
     TRINO = "Trino"
 
     # Not yet supported.

--- a/metricflow/sql/render/doris.py
+++ b/metricflow/sql/render/doris.py
@@ -1,0 +1,23 @@
+from metricflow.sql.render.expr_renderer import SqlExpressionRenderer
+from metricflow.sql.render.mysql import MySQLSqlExpressionRenderer
+from metricflow.sql.render.sql_plan_renderer import DefaultSqlQueryPlanRenderer
+
+
+class DorisSqlExpressionRenderer(MySQLSqlExpressionRenderer):
+    """Expression renderer for Apache Doris.
+
+    Doris supports the MySQL-compatible expressions emitted by MetricFlow's
+    MySQL renderer, including its date and time rendering behavior.
+    """
+
+    pass
+
+
+class DorisSqlQueryPlanRenderer(DefaultSqlQueryPlanRenderer):
+    """Plan renderer for Apache Doris."""
+
+    EXPR_RENDERER = DorisSqlExpressionRenderer()
+
+    @property
+    def expr_renderer(self) -> SqlExpressionRenderer:  # noqa: D
+        return self.EXPR_RENDERER

--- a/metricflow/sql_clients/__init__.py
+++ b/metricflow/sql_clients/__init__.py
@@ -1,4 +1,5 @@
 from metricflow.sql_clients.clickhouse import ClickHouseSqlClient
+from metricflow.sql_clients.doris import DorisSqlClient
 from metricflow.sql_clients.duckdb import DuckDbSqlClient
 from metricflow.sql_clients.greenplum import GreenplumSqlClient
 from metricflow.sql_clients.mysql import MySQLSqlClient
@@ -9,6 +10,7 @@ from metricflow.sql_clients.trino import TrinoSqlClient
 
 __all__ = [
     "ClickHouseSqlClient",
+    "DorisSqlClient",
     "DuckDbSqlClient",
     "GreenplumSqlClient",
     "MySQLSqlClient",

--- a/metricflow/sql_clients/common_client.py
+++ b/metricflow/sql_clients/common_client.py
@@ -18,6 +18,7 @@ class SqlDialect(ExtendedEnum):
     GREENPLUM = "greenplum"
     CLICKHOUSE = "clickhouse"
     STARROCKS = "starrocks"
+    DORIS = "doris"
     TRINO = "trino"
 
 

--- a/metricflow/sql_clients/doris.py
+++ b/metricflow/sql_clients/doris.py
@@ -1,0 +1,173 @@
+import logging
+import textwrap
+import time
+from functools import cached_property
+from typing import ClassVar, Optional, Sequence
+
+import pandas as pd
+import sqlalchemy
+
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes, SqlIsolationLevel
+from metricflow.sql.render.doris import DorisSqlQueryPlanRenderer
+from metricflow.sql.render.sql_plan_renderer import SqlQueryPlanRenderer
+from metricflow.sql.sql_bind_parameters import SqlBindParameters
+from metricflow.sql_clients.common_client import SqlDialect, not_empty
+from metricflow.sql_clients.sqlalchemy_dialect import SqlAlchemySqlClient
+from metricflow.sql_clients.starrocks import StarRocksSqlClient
+
+logger = logging.getLogger(__name__)
+
+
+class DorisEngineAttributes:
+    """Engine-specific attributes for Apache Doris."""
+
+    sql_engine_type: ClassVar[SqlEngine] = SqlEngine.DORIS
+
+    supported_isolation_levels: ClassVar[Sequence[SqlIsolationLevel]] = ()
+    date_trunc_supported: ClassVar[bool] = False
+    full_outer_joins_supported: ClassVar[bool] = False
+    indexes_supported: ClassVar[bool] = True
+    multi_threading_supported: ClassVar[bool] = True
+    timestamp_type_supported: ClassVar[bool] = True
+    timestamp_to_string_comparison_supported: ClassVar[bool] = True
+    cancel_submitted_queries_supported: ClassVar[bool] = True
+    continuous_percentile_aggregation_supported: ClassVar[bool] = True
+    discrete_percentile_aggregation_supported: ClassVar[bool] = True
+    approximate_continuous_percentile_aggregation_supported: ClassVar[bool] = False
+    approximate_discrete_percentile_aggregation_supported: ClassVar[bool] = False
+
+    double_data_type_name: ClassVar[str] = "DOUBLE"
+    timestamp_type_name: ClassVar[Optional[str]] = "TIMESTAMP"
+    random_function_name: ClassVar[str] = "RAND"
+
+    sql_query_plan_renderer: ClassVar[SqlQueryPlanRenderer] = DorisSqlQueryPlanRenderer()
+
+
+class DorisSqlClient(StarRocksSqlClient):
+    """MetricFlow SQL client for Apache Doris.
+
+    Doris and StarRocks both expose a MySQL-compatible wire protocol and the
+    same client-side table management primitives used by MetricFlow. The
+    dialect and engine attributes remain distinct so SQL rendering can evolve
+    independently as the databases diverge.
+    """
+
+    @staticmethod
+    def from_connection_details(url: str, password: Optional[str]) -> SqlAlchemySqlClient:  # noqa: D
+        parsed_url = sqlalchemy.engine.url.make_url(url)
+        dialect = SqlDialect.DORIS.value
+        if parsed_url.drivername != dialect:
+            raise ValueError(f"Expected dialect '{dialect}' in {url}")
+
+        return DorisSqlClient(
+            host=not_empty(parsed_url.host, "host", url),
+            port=not_empty(parsed_url.port, "port", url),
+            username=not_empty(parsed_url.username, "username", url),
+            password=password or "",
+            database=parsed_url.database or "",
+            query=parsed_url.query,
+        )
+
+    @property
+    def sql_engine_attributes(self) -> SqlEngineAttributes:  # noqa: D
+        return DorisEngineAttributes()
+
+    @cached_property
+    def _replication_num(self) -> Optional[int]:
+        """Choose a safe replica count for MetricFlow-managed tables.
+
+        Doris defaults to three replicas, which makes temporary table creation
+        fail in one- or two-backend development clusters. Preserve the default
+        of three when possible and cap it at the number of live backends.
+        """
+        try:
+            backends = self.query("SHOW BACKENDS")
+        except sqlalchemy.exc.SQLAlchemyError:
+            return None
+
+        alive_column = next((column for column in backends.columns if column.lower() == "alive"), None)
+        if alive_column is None:
+            return None
+
+        alive_count = sum(str(value).lower() in {"true", "1"} for value in backends[alive_column])
+        return min(3, alive_count) if alive_count else None
+
+    def _table_properties_sql(self) -> str:
+        if self._replication_num is None:
+            return ""
+        return f'PROPERTIES ("replication_num" = "{self._replication_num}")'
+
+    def create_table_as_select(  # noqa: D
+        self,
+        sql_table: SqlTable,
+        select_query: str,
+        sql_bind_parameters: SqlBindParameters = SqlBindParameters(),
+    ) -> None:
+        properties = self._table_properties_sql()
+        statement_parts = [f"CREATE TABLE {sql_table.sql}"]
+        if properties:
+            statement_parts.append(properties)
+        statement_parts.extend(("AS", textwrap.indent(select_query, "  ")))
+        self.execute("\n".join(statement_parts), sql_bind_parameters=sql_bind_parameters)
+
+    def create_table_from_dataframe(  # noqa: D
+        self, sql_table: SqlTable, df: pd.DataFrame, chunk_size: Optional[int] = None
+    ) -> None:
+        logger.info(f"Creating table '{sql_table.sql}' from a DataFrame with {df.shape[0]} row(s)")
+        start_time = time.time()
+
+        column_definitions = []
+        for col_name, dtype in df.dtypes.items():
+            if dtype == "object":
+                # Doris does not allow TEXT/STRING as an automatically selected
+                # key column, while VARCHAR is supported.
+                sql_type = "VARCHAR(65533)"
+            elif dtype == "int64":
+                sql_type = "BIGINT"
+            elif dtype == "float64":
+                sql_type = "DOUBLE"
+            elif dtype == "bool":
+                sql_type = "BOOLEAN"
+            elif "datetime" in str(dtype):
+                sql_type = "DATETIME"
+            else:
+                sql_type = "VARCHAR(65533)"
+            escaped_col_name = col_name.replace("`", "``")
+            column_definitions.append(f"`{escaped_col_name}` {sql_type}")
+
+        create_table_parts = [f"CREATE TABLE {sql_table.sql} ({', '.join(column_definitions)})"]
+        properties = self._table_properties_sql()
+        if properties:
+            create_table_parts.append(properties)
+        self.execute("\n".join(create_table_parts))
+
+        if chunk_size is None:
+            chunk_size = 1000
+        elif chunk_size <= 0:
+            raise ValueError("chunk_size must be a positive integer")
+
+        for start_idx in range(0, len(df), chunk_size):
+            chunk_df = df.iloc[start_idx : start_idx + chunk_size]
+            values_list = []
+            for _, row in chunk_df.iterrows():
+                values = []
+                for value in row:
+                    if pd.isna(value):
+                        values.append("NULL")
+                    elif isinstance(value, str):
+                        escaped_value = value.replace("'", "''")
+                        values.append(f"'{escaped_value}'")
+                    elif isinstance(value, bool):
+                        values.append("1" if value else "0")
+                    elif isinstance(value, (int, float)):
+                        values.append(str(value))
+                    else:
+                        escaped_value = str(value).replace("'", "''")
+                        values.append(f"'{escaped_value}'")
+                values_list.append(f"({', '.join(values)})")
+
+            if values_list:
+                self.execute(f"INSERT INTO {sql_table.sql} VALUES {', '.join(values_list)}")
+
+        logger.info(f"Created table '{sql_table.sql}' from a DataFrame in {time.time() - start_time:.2f}s")

--- a/metricflow/sql_clients/doris.py
+++ b/metricflow/sql_clients/doris.py
@@ -2,10 +2,11 @@ import logging
 import textwrap
 import time
 from functools import cached_property
-from typing import ClassVar, Optional, Sequence
+from typing import Any, ClassVar, Optional, Sequence
 
 import pandas as pd
 import sqlalchemy
+from pandas.api import types as pandas_types
 
 from metricflow.dataflow.sql_table import SqlTable
 from metricflow.protocols.sql_client import SqlEngine, SqlEngineAttributes, SqlIsolationLevel
@@ -119,21 +120,21 @@ class DorisSqlClient(StarRocksSqlClient):
 
         column_definitions = []
         for col_name, dtype in df.dtypes.items():
-            if dtype == "object":
+            if pandas_types.is_bool_dtype(dtype):
+                sql_type = "BOOLEAN"
+            elif pandas_types.is_integer_dtype(dtype):
+                sql_type = "BIGINT"
+            elif pandas_types.is_float_dtype(dtype):
+                sql_type = "DOUBLE"
+            elif pandas_types.is_datetime64_any_dtype(dtype):
+                sql_type = "DATETIME"
+            elif pandas_types.is_object_dtype(dtype):
                 # Doris does not allow TEXT/STRING as an automatically selected
                 # key column, while VARCHAR is supported.
                 sql_type = "VARCHAR(65533)"
-            elif dtype == "int64":
-                sql_type = "BIGINT"
-            elif dtype == "float64":
-                sql_type = "DOUBLE"
-            elif dtype == "bool":
-                sql_type = "BOOLEAN"
-            elif "datetime" in str(dtype):
-                sql_type = "DATETIME"
             else:
                 sql_type = "VARCHAR(65533)"
-            escaped_col_name = col_name.replace("`", "``")
+            escaped_col_name = str(col_name).replace("`", "``")
             column_definitions.append(f"`{escaped_col_name}` {sql_type}")
 
         create_table_parts = [f"CREATE TABLE {sql_table.sql} ({', '.join(column_definitions)})"]
@@ -147,27 +148,33 @@ class DorisSqlClient(StarRocksSqlClient):
         elif chunk_size <= 0:
             raise ValueError("chunk_size must be a positive integer")
 
-        for start_idx in range(0, len(df), chunk_size):
-            chunk_df = df.iloc[start_idx : start_idx + chunk_size]
-            values_list = []
-            for _, row in chunk_df.iterrows():
-                values = []
-                for value in row:
-                    if pd.isna(value):
-                        values.append("NULL")
-                    elif isinstance(value, str):
-                        escaped_value = value.replace("'", "''")
-                        values.append(f"'{escaped_value}'")
-                    elif isinstance(value, bool):
-                        values.append("1" if value else "0")
-                    elif isinstance(value, (int, float)):
-                        values.append(str(value))
-                    else:
-                        escaped_value = str(value).replace("'", "''")
-                        values.append(f"'{escaped_value}'")
-                values_list.append(f"({', '.join(values)})")
+        escaped_columns = [f"`{str(column).replace('`', '``')}`" for column in df.columns]
+        parameter_names = [f"value_{index}" for index in range(len(df.columns))]
+        placeholders = [f":{name}" for name in parameter_names]
+        insert_statement = sqlalchemy.text(
+            f"INSERT INTO {sql_table.sql} ({', '.join(escaped_columns)}) VALUES ({', '.join(placeholders)})"
+        )
 
-            if values_list:
-                self.execute(f"INSERT INTO {sql_table.sql} VALUES {', '.join(values_list)}")
+        with self._engine_connection(self._engine) as connection:
+            for start_idx in range(0, len(df), chunk_size):
+                chunk_df = df.iloc[start_idx : start_idx + chunk_size]
+                parameter_rows = [
+                    {name: self._normalize_bind_value(value) for name, value in zip(parameter_names, row, strict=True)}
+                    for row in chunk_df.itertuples(index=False, name=None)
+                ]
+                if parameter_rows:
+                    connection.execute(insert_statement, parameter_rows)
+            connection.commit()
 
         logger.info(f"Created table '{sql_table.sql}' from a DataFrame in {time.time() - start_time:.2f}s")
+
+    @staticmethod
+    def _normalize_bind_value(value: Any) -> Any:
+        """Convert pandas and NumPy scalar values into DB-API compatible bind values."""
+        if pd.isna(value):
+            return None
+        if isinstance(value, pd.Timestamp):
+            return value.to_pydatetime()
+
+        item = getattr(value, "item", None)
+        return item() if callable(item) else value

--- a/metricflow/sql_clients/sql_utils.py
+++ b/metricflow/sql_clients/sql_utils.py
@@ -28,6 +28,7 @@ from metricflow.protocols.sql_request import SqlJsonTag
 from metricflow.sql.sql_bind_parameters import SqlBindParameters
 from metricflow.sql_clients.base_sql_client_implementation import SqlClientException
 from metricflow.sql_clients.clickhouse import ClickHouseSqlClient
+from metricflow.sql_clients.doris import DorisSqlClient
 from metricflow.sql_clients.common_client import SqlDialect, not_empty
 from metricflow.sql_clients.duckdb import DuckDbSqlClient
 from metricflow.sql_clients.greenplum import GreenplumSqlClient
@@ -88,6 +89,8 @@ def make_sql_client(url: str, password: str) -> AsyncSqlClient:
         return ClickHouseSqlClient.from_connection_details(url, password)
     elif dialect == SqlDialect.STARROCKS:
         return StarRocksSqlClient.from_connection_details(url, password)
+    elif dialect == SqlDialect.DORIS:
+        return DorisSqlClient.from_connection_details(url, password)
     elif dialect == SqlDialect.TRINO:
         return TrinoSqlClient.from_connection_details(url, password)
     elif dialect == SqlDialect.SQLITE:
@@ -96,7 +99,7 @@ def make_sql_client(url: str, password: str) -> AsyncSqlClient:
         return SnowflakeSqlClient.from_connection_details(url, password)
     else:
         raise ValueError(
-            "Only DuckDB, MySQL, PostgreSQL, Greenplum, ClickHouse, StarRocks, Trino, SQLite, and Snowflake "
+            "Only DuckDB, MySQL, PostgreSQL, Greenplum, ClickHouse, StarRocks, Doris, Trino, SQLite, and Snowflake "
             f"dialects are supported in this build. Got: `{dialect}` in URL {url}"
         )
 
@@ -190,6 +193,18 @@ def make_sql_client_from_config(handler: YamlFileHandler) -> AsyncSqlClient:
         else:
             starrocks_url = f"starrocks://{username}@{host}:{port}"
         return StarRocksSqlClient.from_connection_details(starrocks_url, password)
+    elif dialect == SqlDialect.DORIS.value:
+        host = not_empty(handler.get_value(CONFIG_DWH_HOST), "host", url)
+        port = not_empty(handler.get_value(CONFIG_DWH_PORT), "port", url)
+        username = not_empty(handler.get_value(CONFIG_DWH_USER), "username", url)
+        password = handler.get_value(CONFIG_DWH_PASSWORD) or ""
+        database = handler.get_value(CONFIG_DWH_DB) or ""
+
+        if database:
+            doris_url = f"doris://{username}@{host}:{port}/{database}"
+        else:
+            doris_url = f"doris://{username}@{host}:{port}"
+        return DorisSqlClient.from_connection_details(doris_url, password)
     elif dialect == SqlDialect.TRINO.value:
         host = not_empty(handler.get_value(CONFIG_DWH_HOST), "host", url)
         port = not_empty(handler.get_value(CONFIG_DWH_PORT), "port", url)
@@ -222,7 +237,7 @@ def make_sql_client_from_config(handler: YamlFileHandler) -> AsyncSqlClient:
         )
     else:
         raise ValueError(
-            "Only DuckDB, MySQL, PostgreSQL, Greenplum, ClickHouse, StarRocks, Trino, SQLite, and Snowflake "
+            "Only DuckDB, MySQL, PostgreSQL, Greenplum, ClickHouse, StarRocks, Doris, Trino, SQLite, and Snowflake "
             f"dialects are supported in this build. Got dialect '{dialect}' in {url}"
         )
 

--- a/metricflow/test/integration/test_doris_integration.py
+++ b/metricflow/test/integration/test_doris_integration.py
@@ -9,6 +9,7 @@ import shutil
 import tempfile
 from string import Template
 
+import pandas as pd
 import pytest
 import sqlalchemy.exc
 
@@ -125,6 +126,30 @@ class TestDorisDatabaseOperations:
             assert len(result) == 1
             assert set(result.columns) == {"answer", "greeting"}
             assert table.table_name in doris_client.list_tables(DORIS_DATABASE)
+        finally:
+            doris_client.execute(f"DROP TABLE IF EXISTS {table.sql}")
+
+    def test_create_table_from_dataframe_with_bound_values(self, doris_client) -> None:
+        table = SqlTable(schema_name=DORIS_DATABASE, table_name=f"doris_dataframe_test_{random_id()}")
+        dataframe = pd.DataFrame(
+            {
+                "name": ["O'Reilly\\", None],
+                "count_value": pd.Series([1, pd.NA], dtype="Int64"),
+                "enabled": pd.Series([True, pd.NA], dtype="boolean"),
+            }
+        )
+        try:
+            doris_client.create_table_from_dataframe(table, dataframe)
+
+            populated = doris_client.query(f"SELECT name, count_value, enabled FROM {table.sql} WHERE count_value = 1")
+            assert populated.iloc[0]["name"] == "O'Reilly\\"
+            assert populated.iloc[0]["count_value"] == 1
+            assert bool(populated.iloc[0]["enabled"])
+
+            null_row = doris_client.query(
+                f"SELECT name, count_value, enabled FROM {table.sql} WHERE count_value IS NULL"
+            )
+            assert null_row.iloc[0].isna().all()
         finally:
             doris_client.execute(f"DROP TABLE IF EXISTS {table.sql}")
 

--- a/metricflow/test/integration/test_doris_integration.py
+++ b/metricflow/test/integration/test_doris_integration.py
@@ -1,0 +1,181 @@
+"""Live end-to-end tests for Apache Doris.
+
+Set DORIS_HOST, DORIS_PORT, DORIS_USER, DORIS_PASSWORD, and DORIS_DATABASE
+when the test database is not available at the local defaults.
+"""
+
+import os
+import shutil
+import tempfile
+from string import Template
+
+import pytest
+import sqlalchemy.exc
+
+from metricflow.cli.tutorial import (
+    COUNTRIES_TABLE,
+    COUNTRIES_YAML_FILE,
+    CUSTOMERS_TABLE,
+    CUSTOMERS_YAML_FILE,
+    TRANSACTIONS_TABLE,
+    TRANSACTIONS_YAML_FILE,
+    create_sample_data,
+    remove_sample_tables,
+)
+from metricflow.configuration.dict_config_handler import DictConfigHandler, build_config_dict_from_db_params
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.engine.metricflow_engine import MetricFlowEngine, MetricFlowQueryRequest
+from metricflow.engine.utils import model_build_result_from_config
+from metricflow.model.data_warehouse_model_validator import DataWarehouseModelValidator
+from metricflow.model.model_validator import ModelValidator
+from metricflow.model.validations.validator_helpers import ModelValidationResults
+from metricflow.object_utils import random_id
+from metricflow.protocols.sql_client import SqlEngine
+from metricflow.sql.render.doris import DorisSqlQueryPlanRenderer
+from metricflow.sql_clients.doris import DorisSqlClient
+from metricflow.sql_clients.sql_utils import make_sql_client_from_config
+
+
+DORIS_HOST = os.getenv("DORIS_HOST", "localhost")
+DORIS_PORT = os.getenv("DORIS_PORT", "9030")
+DORIS_USER = os.getenv("DORIS_USER", "root")
+DORIS_PASSWORD = os.getenv("DORIS_PASSWORD", "")
+DORIS_DATABASE = os.getenv("DORIS_DATABASE", "test")
+DORIS_URL = f"doris://{DORIS_USER}@{DORIS_HOST}:{DORIS_PORT}/{DORIS_DATABASE}"
+
+
+def _make_doris_client():
+    try:
+        client = DorisSqlClient.from_connection_details(DORIS_URL, DORIS_PASSWORD)
+        client.query("SELECT 1")
+        return client
+    except (sqlalchemy.exc.OperationalError, ConnectionError, OSError):
+        return None
+
+
+@pytest.fixture(scope="module")
+def doris_client():
+    client = _make_doris_client()
+    if client is None:
+        pytest.skip(f"Doris is not available at {DORIS_HOST}:{DORIS_PORT}/{DORIS_DATABASE}")
+    yield client
+    client.close()
+
+
+@pytest.fixture(scope="module")
+def doris_model_dir():
+    model_dir = tempfile.mkdtemp(prefix="doris_test_models_")
+    for yaml_file, table_name in (
+        (TRANSACTIONS_YAML_FILE, f"{DORIS_DATABASE}.{TRANSACTIONS_TABLE}"),
+        (CUSTOMERS_YAML_FILE, f"{DORIS_DATABASE}.{CUSTOMERS_TABLE}"),
+        (COUNTRIES_YAML_FILE, f"{DORIS_DATABASE}.{COUNTRIES_TABLE}"),
+    ):
+        with open(yaml_file) as source:
+            variable = os.path.basename(yaml_file).replace(".yaml", "_table")
+            contents = Template(source.read()).substitute({variable: table_name})
+        with open(os.path.join(model_dir, os.path.basename(yaml_file)), "w") as destination:
+            destination.write(contents)
+    yield model_dir
+    shutil.rmtree(model_dir, ignore_errors=True)
+
+
+def _handler(model_dir: str) -> DictConfigHandler:
+    return DictConfigHandler(
+        build_config_dict_from_db_params(
+            db_type="doris",
+            host=DORIS_HOST,
+            port=DORIS_PORT,
+            username=DORIS_USER,
+            password=DORIS_PASSWORD,
+            database=DORIS_DATABASE,
+            model_path=model_dir,
+        )
+    )
+
+
+@pytest.fixture(scope="module")
+def doris_sample_data(doris_client):
+    remove_sample_tables(sql_client=doris_client, system_schema=DORIS_DATABASE)
+    assert create_sample_data(sql_client=doris_client, system_schema=DORIS_DATABASE)
+    yield
+    remove_sample_tables(sql_client=doris_client, system_schema=DORIS_DATABASE)
+
+
+@pytest.mark.doris
+class TestDorisDatabaseOperations:
+    def test_engine_attributes(self, doris_client) -> None:
+        attributes = doris_client.sql_engine_attributes
+        assert attributes.sql_engine_type is SqlEngine.DORIS
+        assert isinstance(attributes.sql_query_plan_renderer, DorisSqlQueryPlanRenderer)
+
+    def test_health_checks(self, doris_client) -> None:
+        for name, result in doris_client.health_checks(schema_name=DORIS_DATABASE).items():
+            assert result["status"] == "SUCCESS", f"{name}: {result}"
+
+    def test_query_and_dry_run(self, doris_client) -> None:
+        result = doris_client.query("SELECT 1 AS value")
+        assert result.iloc[0]["value"] == 1
+        doris_client.dry_run("SELECT 1")
+
+    def test_create_list_and_drop_table(self, doris_client) -> None:
+        table = SqlTable(schema_name=DORIS_DATABASE, table_name=f"doris_test_{random_id()}")
+        try:
+            doris_client.create_table_as_select(table, "SELECT 42 AS answer, 'hello' AS greeting")
+            result = doris_client.query(f"SELECT * FROM {table.sql}")
+            assert len(result) == 1
+            assert set(result.columns) == {"answer", "greeting"}
+            assert table.table_name in doris_client.list_tables(DORIS_DATABASE)
+        finally:
+            doris_client.execute(f"DROP TABLE IF EXISTS {table.sql}")
+
+
+@pytest.mark.doris
+class TestDorisMetricFlowPipeline:
+    def test_config_factory(self, doris_client, doris_model_dir) -> None:
+        client = make_sql_client_from_config(_handler(doris_model_dir))
+        try:
+            assert isinstance(client, DorisSqlClient)
+            assert client.query("SELECT 1").iloc[0, 0] == 1
+        finally:
+            client.close()
+
+    def test_model_and_warehouse_validation(self, doris_client, doris_model_dir, doris_sample_data) -> None:
+        build_result = model_build_result_from_config(
+            handler=_handler(doris_model_dir), raise_issues_as_exceptions=False
+        )
+        assert not build_result.issues.has_blocking_issues, build_result.issues.summary()
+
+        semantic_result = ModelValidator().validate_model(build_result.model)
+        assert not semantic_result.issues.has_blocking_issues, semantic_result.issues.summary()
+
+        validator = DataWarehouseModelValidator(sql_client=doris_client, system_schema=DORIS_DATABASE)
+        results = [
+            validate(build_result.model, None)
+            for validate in (
+                validator.validate_data_sources,
+                validator.validate_dimensions,
+                validator.validate_identifiers,
+                validator.validate_measures,
+            )
+        ]
+        merged = ModelValidationResults.merge(results)
+        assert not merged.has_blocking_issues, merged.summary()
+
+    def test_query_metric(self, doris_model_dir, doris_sample_data) -> None:
+        engine = MetricFlowEngine.from_config(_handler(doris_model_dir))
+        metrics = {metric.name for metric in engine.list_metrics()}
+        assert "transactions" in metrics
+
+        request = MetricFlowQueryRequest.create_with_random_request_id(
+            metric_names=["transactions"],
+            group_by_names=["metric_time"],
+            order_by_names=["metric_time"],
+            limit=5,
+        )
+        explain_result = engine.explain(mf_request=request)
+        assert "SELECT" in explain_result.rendered_sql_without_descriptions.sql_query
+
+        result = engine.query(mf_request=request).result_df
+        assert result is not None
+        assert len(result) > 0
+        assert {"transactions", "metric_time"}.issubset(result.columns)

--- a/metricflow/test/sql_clients/test_async.py
+++ b/metricflow/test/sql_clients/test_async.py
@@ -196,6 +196,7 @@ def test_request_tags(
         or engine_type is SqlEngine.MYSQL
         or engine_type is SqlEngine.CLICKHOUSE
         or engine_type is SqlEngine.STARROCKS
+        or engine_type is SqlEngine.DORIS
         or engine_type is SqlEngine.TRINO
     ):
         pytest.skip(f"Testing tags not supported in {engine_type}")

--- a/metricflow/test/sql_clients/test_doris_client.py
+++ b/metricflow/test/sql_clients/test_doris_client.py
@@ -129,22 +129,53 @@ class TestDorisClient:
         assert 'PROPERTIES ("replication_num" = "1")' in statement
         assert statement.endswith("AS\n  SELECT 1 AS value")
 
-    def test_dataframe_table_uses_doris_key_compatible_string_type(self) -> None:
+    def test_dataframe_table_uses_doris_types_and_parameterized_inserts(self) -> None:
         client = self._client()
+        connection = MagicMock()
         with (
             patch.object(client, "query", return_value=pd.DataFrame({"Alive": ["true"]})),
             patch.object(client, "execute") as execute,
+            patch.object(client, "_engine_connection") as engine_connection,
         ):
+            engine_connection.return_value.__enter__.return_value = connection
             client.create_table_from_dataframe(
                 SqlTable(schema_name="test", table_name="sample"),
-                pd.DataFrame({"name": ["O'Reilly"], "score": [1]}),
+                pd.DataFrame(
+                    {
+                        "name": ["O'Reilly\\", None],
+                        "int32_value": pd.Series([1, 2], dtype="int32"),
+                        "nullable_int": pd.Series([3, pd.NA], dtype="Int64"),
+                        "float32_value": pd.Series([1.5, 2.5], dtype="float32"),
+                        "nullable_float": pd.Series([3.5, pd.NA], dtype="Float64"),
+                        "nullable_bool": pd.Series([True, pd.NA], dtype="boolean"),
+                        "event_time": pd.to_datetime(["2026-07-21", None]),
+                    }
+                ),
             )
 
-        create_statement = execute.call_args_list[0].args[0]
-        insert_statement = execute.call_args_list[1].args[0]
+        create_statement = execute.call_args.args[0]
         assert "`name` VARCHAR(65533)" in create_statement
+        assert "`int32_value` BIGINT" in create_statement
+        assert "`nullable_int` BIGINT" in create_statement
+        assert "`float32_value` DOUBLE" in create_statement
+        assert "`nullable_float` DOUBLE" in create_statement
+        assert "`nullable_bool` BOOLEAN" in create_statement
+        assert "`event_time` DATETIME" in create_statement
         assert 'PROPERTIES ("replication_num" = "1")' in create_statement
-        assert "'O''Reilly'" in insert_statement
+
+        insert_statement, parameter_rows = connection.execute.call_args.args
+        assert str(insert_statement).startswith("INSERT INTO test.sample (`name`, `int32_value`")
+        assert "VALUES (:value_0, :value_1, :value_2, :value_3, :value_4, :value_5, :value_6)" in str(insert_statement)
+        assert parameter_rows[0]["value_0"] == "O'Reilly\\"
+        assert parameter_rows[0]["value_1"] == 1
+        assert isinstance(parameter_rows[0]["value_1"], int)
+        assert parameter_rows[0]["value_5"] is True
+        assert parameter_rows[1]["value_0"] is None
+        assert parameter_rows[1]["value_2"] is None
+        assert parameter_rows[1]["value_4"] is None
+        assert parameter_rows[1]["value_5"] is None
+        assert parameter_rows[1]["value_6"] is None
+        connection.commit.assert_called_once_with()
 
 
 class TestDorisRenderer:

--- a/metricflow/test/sql_clients/test_doris_client.py
+++ b/metricflow/test/sql_clients/test_doris_client.py
@@ -1,0 +1,173 @@
+from typing import cast
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from metricflow.cli.utils import MF_DORIS_KEYS
+from metricflow.configuration.constants import (
+    CONFIG_DWH_DB,
+    CONFIG_DWH_DIALECT,
+    CONFIG_DWH_HOST,
+    CONFIG_DWH_PASSWORD,
+    CONFIG_DWH_PORT,
+    CONFIG_DWH_SCHEMA,
+    CONFIG_DWH_USER,
+)
+from metricflow.configuration.dict_config_handler import (
+    DIALECT_MAPPING,
+    DictConfigHandler,
+    build_config_dict_from_db_params,
+)
+from metricflow.dataflow.sql_table import SqlTable
+from metricflow.protocols.sql_client import SqlEngine
+from metricflow.sql.render.doris import DorisSqlQueryPlanRenderer
+from metricflow.sql.sql_exprs import SqlColumnReference, SqlColumnReferenceExpression
+from metricflow.sql.sql_plan import (
+    SqlQueryPlan,
+    SqlSelectColumn,
+    SqlSelectStatementNode,
+    SqlTableFromClauseNode,
+)
+from metricflow.sql_clients.common_client import SqlDialect
+from metricflow.sql_clients.doris import DorisEngineAttributes, DorisSqlClient
+from metricflow.sql_clients.sql_utils import make_sql_client, make_sql_client_from_config
+
+
+class TestDorisConfig:
+    def test_build_config(self) -> None:
+        config = build_config_dict_from_db_params(
+            db_type="doris",
+            host="doris-host",
+            port="9030",
+            username="root",
+            password="secret",
+            database="analytics",
+        )
+
+        assert DIALECT_MAPPING["doris"] == "doris"
+        assert config[CONFIG_DWH_DIALECT] == "doris"
+        assert config[CONFIG_DWH_HOST] == "doris-host"
+        assert config[CONFIG_DWH_PORT] == "9030"
+        assert config[CONFIG_DWH_USER] == "root"
+        assert config[CONFIG_DWH_PASSWORD] == "secret"
+        assert config[CONFIG_DWH_DB] == "analytics"
+        assert config[CONFIG_DWH_SCHEMA] == "analytics"
+
+    def test_factory_uses_doris_client(self) -> None:
+        handler = DictConfigHandler(
+            build_config_dict_from_db_params(
+                db_type="doris",
+                host="doris-host",
+                port="9030",
+                username="root",
+                database="analytics",
+            )
+        )
+
+        with patch.object(DorisSqlClient, "from_connection_details", return_value=MagicMock()) as factory:
+            make_sql_client_from_config(handler)
+
+        factory.assert_called_once_with("doris://root@doris-host:9030/analytics", "")
+
+    def test_url_factory_uses_doris_client(self) -> None:
+        with patch.object(DorisSqlClient, "from_connection_details", return_value=MagicMock()) as factory:
+            make_sql_client("doris://root@doris-host:9030/analytics", "secret")
+
+        factory.assert_called_once_with("doris://root@doris-host:9030/analytics", "secret")
+
+    def test_cli_setup_keys_include_doris(self) -> None:
+        assert any(k.key == CONFIG_DWH_DIALECT and k.value == "doris" for k in MF_DORIS_KEYS)
+
+
+class TestDorisClient:
+    @staticmethod
+    def _client() -> DorisSqlClient:
+        with patch.object(DorisSqlClient, "create_engine", return_value=MagicMock()):
+            return cast(
+                DorisSqlClient,
+                DorisSqlClient.from_connection_details("doris://root@localhost:9030/test", ""),
+            )
+
+    def test_dialect_and_engine_are_distinct(self) -> None:
+        assert SqlDialect.DORIS.value == "doris"
+        assert SqlEngine.DORIS.value == "Doris"
+
+    def test_rejects_non_doris_url(self) -> None:
+        with pytest.raises(ValueError, match="Expected dialect 'doris'"):
+            DorisSqlClient.from_connection_details("starrocks://root@localhost:9030/test", "")
+
+    def test_uses_mysql_wire_protocol(self) -> None:
+        with patch.object(DorisSqlClient, "create_engine", return_value=MagicMock()) as create_engine:
+            client = DorisSqlClient.from_connection_details("doris://root@localhost:9030/test", "")
+
+        assert isinstance(client, DorisSqlClient)
+        create_engine.assert_called_once_with(
+            dialect="mysql",
+            driver="pymysql",
+            port=9030,
+            database="test",
+            username="root",
+            password="",
+            host="localhost",
+            query={},
+        )
+
+    def test_engine_attributes_use_doris_renderer(self) -> None:
+        assert DorisEngineAttributes.sql_engine_type is SqlEngine.DORIS
+        assert isinstance(DorisEngineAttributes.sql_query_plan_renderer, DorisSqlQueryPlanRenderer)
+
+    def test_ctas_caps_replication_at_live_backend_count(self) -> None:
+        client = self._client()
+        with (
+            patch.object(client, "query", return_value=pd.DataFrame({"Alive": ["true", "false"]})),
+            patch.object(client, "execute") as execute,
+        ):
+            client.create_table_as_select(SqlTable(schema_name="test", table_name="result"), "SELECT 1 AS value")
+
+        statement = execute.call_args.args[0]
+        assert 'PROPERTIES ("replication_num" = "1")' in statement
+        assert statement.endswith("AS\n  SELECT 1 AS value")
+
+    def test_dataframe_table_uses_doris_key_compatible_string_type(self) -> None:
+        client = self._client()
+        with (
+            patch.object(client, "query", return_value=pd.DataFrame({"Alive": ["true"]})),
+            patch.object(client, "execute") as execute,
+        ):
+            client.create_table_from_dataframe(
+                SqlTable(schema_name="test", table_name="sample"),
+                pd.DataFrame({"name": ["O'Reilly"], "score": [1]}),
+            )
+
+        create_statement = execute.call_args_list[0].args[0]
+        insert_statement = execute.call_args_list[1].args[0]
+        assert "`name` VARCHAR(65533)" in create_statement
+        assert 'PROPERTIES ("replication_num" = "1")' in create_statement
+        assert "'O''Reilly'" in insert_statement
+
+
+class TestDorisRenderer:
+    def test_renders_simple_select(self) -> None:
+        select_node = SqlSelectStatementNode(
+            description="Doris simple query",
+            select_columns=(
+                SqlSelectColumn(
+                    expr=SqlColumnReferenceExpression(SqlColumnReference("a", "revenue")),
+                    column_alias="revenue",
+                ),
+            ),
+            from_source=SqlTableFromClauseNode(sql_table=SqlTable(schema_name="test", table_name="sales")),
+            from_source_alias="a",
+            joins_descs=(),
+            where=None,
+            group_bys=(),
+            order_bys=(),
+        )
+        rendered = DorisSqlQueryPlanRenderer().render_sql_query_plan(
+            SqlQueryPlan(plan_id="doris_test", render_node=select_node)
+        )
+
+        assert "SELECT" in rendered.sql
+        assert "a.revenue" in rendered.sql
+        assert "test.sales" in rendered.sql

--- a/metricflow/test/sql_clients/test_sql_client.py
+++ b/metricflow/test/sql_clients/test_sql_client.py
@@ -179,6 +179,7 @@ def _issue_sleep_query(sql_client: SqlClient, sleep_time: int) -> None:
         or engine_type is SqlEngine.MYSQL
         or engine_type is SqlEngine.CLICKHOUSE
         or engine_type is SqlEngine.STARROCKS
+        or engine_type is SqlEngine.DORIS
         or engine_type is SqlEngine.TRINO
     ):
         raise RuntimeError(f"Sleep yet not supported with {engine_type}")
@@ -201,6 +202,7 @@ def _supports_sleep_query(sql_client: SqlClient) -> bool:
         or engine_type is SqlEngine.MYSQL
         or engine_type is SqlEngine.CLICKHOUSE
         or engine_type is SqlEngine.STARROCKS
+        or engine_type is SqlEngine.DORIS
         or engine_type is SqlEngine.TRINO
     ):
         return False

--- a/metricflow/test/test_dict_config_handler.py
+++ b/metricflow/test/test_dict_config_handler.py
@@ -58,6 +58,18 @@ class TestBuildConfigDictFromDbParams:
         assert result[CONFIG_DWH_DIALECT] == "starrocks"
         assert result[CONFIG_DWH_SCHEMA] == "sr_db"
 
+    def test_doris(self):
+        result = build_config_dict_from_db_params(
+            db_type="doris",
+            host="doris-host",
+            port="9030",
+            username="root",
+            password="pw",
+            database="doris_db",
+        )
+        assert result[CONFIG_DWH_DIALECT] == "doris"
+        assert result[CONFIG_DWH_SCHEMA] == "doris_db"
+
     def test_postgresql(self):
         result = build_config_dict_from_db_params(
             db_type="postgresql",
@@ -349,6 +361,10 @@ agent:
         type: starrocks
         host: sr-host
         database_name: runtime_db
+      doris:
+        type: doris
+        host: doris-host
+        database_name: doris_db
       trino:
         type: trino
         host: trino-host
@@ -361,6 +377,11 @@ agent:
         starrocks_handler = DatusConfigHandler("starrocks", config_path=str(config_path))
         assert starrocks_handler.get_value(CONFIG_DWH_DB) == "runtime_db"
         assert starrocks_handler.get_value(CONFIG_DWH_SCHEMA) == "runtime_db"
+
+        doris_handler = DatusConfigHandler("doris", config_path=str(config_path))
+        assert doris_handler.get_value(CONFIG_DWH_DIALECT) == "doris"
+        assert doris_handler.get_value(CONFIG_DWH_DB) == "doris_db"
+        assert doris_handler.get_value(CONFIG_DWH_SCHEMA) == "doris_db"
 
         trino_handler = DatusConfigHandler("trino", config_path=str(config_path))
         assert trino_handler.get_value(CONFIG_DWH_DB) == "tpch"


### PR DESCRIPTION
## Summary

- add a native `doris` SQL dialect, engine, renderer, and SQL client
- support Doris through MetricFlow URL/config factories, Datus config, dictionary config, and CLI setup
- make MetricFlow-managed tables work with Doris backend replica counts and Doris-compatible string key types
- add unit tests, live Doris integration coverage, and usage documentation

## Why

The Apache Doris adapter can connect through the MySQL wire protocol, but MetricFlow previously had no Doris dialect or client mapping. Semantic-layer workflows therefore could not select Doris natively and had to masquerade as another engine.

This change gives Doris its own dialect and engine identity while reusing compatible MySQL-wire primitives. The renderer and client remain separate so Doris-specific behavior can evolve independently.

## Validation

- commit hooks: Black, Flake8, and mypy passed
- full MetricFlow suite: `781 passed, 70 skipped`
- Apache Doris 4.0.7 live integration suite: `7 passed`
- Baisheng stable end-to-end benchmark with native Doris MetricFlow:
  - semantic model: `2/2`
  - reference SQL: `2/2`
  - combined: `4/4` (`100%`)
- `poetry build` passed for both sdist and wheel


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Apache Doris as a supported MetricFlow data source.
  * Added Doris connection configuration, SQL querying, table creation, health checks, and metric workflows.
  * Added Doris support to CLI setup and datasource configuration.
  * Added documentation and command examples for using Doris through Datus.
* **Bug Fixes**
  * Improved schema and database handling for Doris configurations.
* **Tests**
  * Added coverage for Doris connections, SQL rendering, table operations, configuration, and end-to-end metric queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->