### PR TITLE
Map Datus hologres datasource to the PostgreSQL dialect

### DIFF
--- a/README-DATUS.md
+++ b/README-DATUS.md
@@ -154,7 +154,8 @@ For detailed MCP server documentation, see [MCP-SERVER.md](MCP-SERVER.md).
 | SQLite | ✅ Full | File-based |
 | MySQL | ✅ Full | Network database |
 | StarRocks | ✅ Full | Uses MySQL protocol |
-| PostgreSQL | ⚠️ Config only | Client not in this build |
+| PostgreSQL | ✅ Full | Network database |
+| Hologres | ✅ Full | Keep `type: hologres`; executes through the PostgreSQL client |
 | Snowflake | ✅ Full | Password or RSA key pair auth; requires Snowflake dependencies |
 | BigQuery | ⚠️ Config only | Client not in this build |
 

--- a/metricflow/configuration/datus_config_handler.py
+++ b/metricflow/configuration/datus_config_handler.py
@@ -24,6 +24,7 @@ from metricflow.configuration.constants import (
     CONFIG_EMAIL,
     CONFIG_DWH_SSLMODE,
 )
+from metricflow.configuration.dict_config_handler import DIALECT_MAPPING
 from metricflow.configuration.yaml_handler import YamlFileHandler
 
 
@@ -147,21 +148,7 @@ class DatusConfigHandler(YamlFileHandler):
 
         # Map database dialect
         if key == CONFIG_DWH_DIALECT:
-            # Map Datus DB types to MetricFlow dialects
-            dialect_mapping = {
-                "postgres": "postgresql",
-                "postgresql": "postgresql",
-                "greenplum": "greenplum",
-                "mysql": "mysql",
-                "starrocks": "starrocks",
-                "clickhouse": "clickhouse",
-                "trino": "trino",
-                "duckdb": "duckdb",
-                "sqlite": "sqlite",
-                "snowflake": "snowflake",
-                "bigquery": "bigquery",
-            }
-            return dialect_mapping.get(db_type, db_type)
+            return DIALECT_MAPPING.get(db_type, db_type)
 
         # Common mappings for most SQL databases
         if key == CONFIG_DWH_HOST:
@@ -215,7 +202,7 @@ class DatusConfigHandler(YamlFileHandler):
                 if catalog and database:
                     return self._resolve_env_vars(database)
                 return "default"
-            elif db_type in ("postgres", "postgresql", "greenplum"):
+            elif db_type in ("postgres", "postgresql", "hologres", "greenplum"):
                 return "public"
             else:
                 return self._resolve_env_vars(self.db_config.get("schema") or self.db_config.get("schema_name") or "")

--- a/metricflow/configuration/dict_config_handler.py
+++ b/metricflow/configuration/dict_config_handler.py
@@ -23,10 +23,14 @@ from metricflow.configuration.constants import (
 )
 from metricflow.configuration.yaml_handler import YamlFileHandler
 
-# Mapping from Datus DB types to MetricFlow dialect names
+# Mapping from Datus DB types to MetricFlow dialect names.
+# Hologres speaks the PostgreSQL wire protocol and has no MetricFlow dialect of
+# its own, so it executes through the PostgreSQL client. Datus configs keep
+# `type: hologres` so the Hologres datasource adapter stays in effect.
 DIALECT_MAPPING = {
     "postgres": "postgresql",
     "postgresql": "postgresql",
+    "hologres": "postgresql",
     "greenplum": "greenplum",
     "mysql": "mysql",
     "starrocks": "starrocks",
@@ -45,6 +49,7 @@ DEFAULT_SCHEMA_MAPPING = {
     "mysql": "default",
     "postgres": "public",
     "postgresql": "public",
+    "hologres": "public",
     "greenplum": "public",
 }
 

--- a/metricflow/test/sql_clients/test_hologres_dialect.py
+++ b/metricflow/test/sql_clients/test_hologres_dialect.py
@@ -1,0 +1,60 @@
+"""Tests that a Datus `hologres` datasource executes through the PostgreSQL client.
+
+Hologres speaks the PostgreSQL wire protocol and has no MetricFlow dialect of its
+own, so `type: hologres` is mapped to the `postgresql` dialect at config-build
+time. No database connection is made here — the client factory is patched, and the
+unpatched construction test relies on SQLAlchemy engines being lazy.
+"""
+
+from unittest import mock
+
+import pytest
+
+from metricflow.configuration.constants import CONFIG_DWH_DIALECT
+from metricflow.configuration.dict_config_handler import (
+    DictConfigHandler,
+    build_config_dict_from_datus_datasource,
+)
+from metricflow.sql_clients.common_client import SqlDialect
+from metricflow.sql_clients.postgres import PostgresSqlClient
+from metricflow.sql_clients.sql_utils import make_sql_client_from_config
+
+HOLOGRES_DATASOURCE = {
+    "type": "hologres",
+    "host": "holo-host",
+    "port": 80,
+    "username": "holo_user",
+    "password": "holo_pw",
+    "database": "njyh",
+    "sslmode": "require",
+}
+
+
+def _handler(**overrides) -> DictConfigHandler:
+    return DictConfigHandler(build_config_dict_from_datus_datasource({**HOLOGRES_DATASOURCE, **overrides}))
+
+
+class TestHologresClientSelection:
+    def test_config_uses_postgresql_dialect(self) -> None:
+        assert _handler().get_value(CONFIG_DWH_DIALECT) == SqlDialect.POSTGRESQL.value
+
+    def test_factory_builds_postgres_client_with_sslmode(self) -> None:
+        with mock.patch.object(PostgresSqlClient, "from_connection_details") as from_connection_details:
+            make_sql_client_from_config(_handler())
+
+        from_connection_details.assert_called_once_with(
+            "postgresql://holo_user@holo-host:80/njyh?sslmode=require", "holo_pw"
+        )
+
+    def test_factory_omits_sslmode_when_not_configured(self) -> None:
+        with mock.patch.object(PostgresSqlClient, "from_connection_details") as from_connection_details:
+            make_sql_client_from_config(_handler(sslmode=""))
+
+        from_connection_details.assert_called_once_with("postgresql://holo_user@holo-host:80/njyh", "holo_pw")
+
+    def test_factory_returns_postgres_client_instance(self) -> None:
+        pytest.importorskip("psycopg2")
+
+        client = make_sql_client_from_config(_handler())
+
+        assert isinstance(client, PostgresSqlClient)

--- a/metricflow/test/test_dict_config_handler.py
+++ b/metricflow/test/test_dict_config_handler.py
@@ -77,6 +77,39 @@ class TestBuildConfigDictFromDbParams:
         assert result[CONFIG_DWH_DIALECT] == "postgresql"
         assert result[CONFIG_DWH_SCHEMA] == "public"
 
+    def test_hologres_maps_to_postgresql_dialect(self):
+        result = build_config_dict_from_db_params(
+            db_type="hologres",
+            host="holo-host",
+            port="80",
+            username="holo_user",
+            password="holo_pw",
+            database="holo_db",
+            sslmode="require",
+        )
+        assert result[CONFIG_DWH_DIALECT] == "postgresql"
+        assert result[CONFIG_DWH_HOST] == "holo-host"
+        assert result[CONFIG_DWH_PORT] == "80"
+        assert result[CONFIG_DWH_USER] == "holo_user"
+        assert result[CONFIG_DWH_PASSWORD] == "holo_pw"
+        assert result[CONFIG_DWH_DB] == "holo_db"
+        assert result[CONFIG_DWH_SSLMODE] == "require"
+        assert result[CONFIG_DWH_SCHEMA] == "public"
+
+    def test_hologres_explicit_schema_overrides_default(self):
+        result = build_config_dict_from_db_params(
+            db_type="hologres",
+            database="holo_db",
+            schema="njyh",
+        )
+        assert result[CONFIG_DWH_DIALECT] == "postgresql"
+        assert result[CONFIG_DWH_SCHEMA] == "njyh"
+
+    def test_hologres_db_type_is_case_insensitive(self):
+        result = build_config_dict_from_db_params(db_type="Hologres")
+        assert result[CONFIG_DWH_DIALECT] == "postgresql"
+        assert result[CONFIG_DWH_SCHEMA] == "public"
+
     def test_duckdb_with_uri(self):
         result = build_config_dict_from_db_params(
             db_type="duckdb",
@@ -262,6 +295,31 @@ class TestBuildConfigDictFromDatusDatasource:
         assert result[CONFIG_DWH_SSLMODE] == "require"
         assert result[CONFIG_MODEL_PATH] == "/tmp/models"
 
+    def test_builds_config_from_raw_hologres_datasource(self):
+        result = build_config_dict_from_datus_datasource(
+            {
+                "type": "hologres",
+                "host": "holo-host",
+                "port": 80,
+                "username": "holo_user",
+                "password": "secret",
+                "database": "njyh",
+                "schema_name": "public_data",
+                "sslmode": "require",
+            },
+            model_path="/tmp/models",
+        )
+
+        assert result[CONFIG_DWH_DIALECT] == "postgresql"
+        assert result[CONFIG_DWH_HOST] == "holo-host"
+        assert result[CONFIG_DWH_PORT] == "80"
+        assert result[CONFIG_DWH_USER] == "holo_user"
+        assert result[CONFIG_DWH_PASSWORD] == "secret"
+        assert result[CONFIG_DWH_DB] == "njyh"
+        assert result[CONFIG_DWH_SCHEMA] == "public_data"
+        assert result[CONFIG_DWH_SSLMODE] == "require"
+        assert result[CONFIG_MODEL_PATH] == "/tmp/models"
+
     def test_builds_config_from_runtime_trino_context(self):
         result = build_config_dict_from_datus_datasource(
             {
@@ -365,6 +423,40 @@ agent:
         trino_handler = DatusConfigHandler("trino", config_path=str(config_path))
         assert trino_handler.get_value(CONFIG_DWH_DB) == "tpch"
         assert trino_handler.get_value(CONFIG_DWH_SCHEMA) == "tiny"
+
+    def test_get_value_maps_hologres_to_postgresql_dialect(self, tmp_path):
+        config_path = tmp_path / "agent.yml"
+        config_path.write_text(
+            """
+agent:
+  services:
+    datasources:
+      hologres:
+        type: hologres
+        host: holo-host
+        port: 80
+        username: holo_user
+        password: secret
+        database: njyh
+        sslmode: require
+""",
+            encoding="utf-8",
+        )
+
+        handler = DatusConfigHandler(
+            datasource="hologres",
+            config_path=str(config_path),
+            project_root=str(tmp_path),
+        )
+
+        assert handler.get_value(CONFIG_DWH_DIALECT) == "postgresql"
+        assert handler.get_value(CONFIG_DWH_HOST) == "holo-host"
+        assert handler.get_value(CONFIG_DWH_PORT) == "80"
+        assert handler.get_value(CONFIG_DWH_USER) == "holo_user"
+        assert handler.get_value(CONFIG_DWH_PASSWORD) == "secret"
+        assert handler.get_value(CONFIG_DWH_DB) == "njyh"
+        assert handler.get_value(CONFIG_DWH_SCHEMA) == "public"
+        assert handler.get_value(CONFIG_DWH_SSLMODE) == "require"
 
     def test_get_value_returns_sslmode_from_datasource_config(self, tmp_path):
         config_path = tmp_path / "agent.yml"


### PR DESCRIPTION
## Problem

With `semantic: osi`, model authoring/validation runs through `DatusOSIAdapter`, but SQL compilation, warehouse validation and execution are still delegated to MetricFlow:

```
Datus Agent -> OSI YAML -> OSI IR -> MetricFlow backend -> Hologres
```

`datus-semantic-adapter` #66 already maps `hologres` to `postgres` for OSI/SQLGlot, which fixed expression parsing and SQL rendering. But the raw `db_config.type=hologres` was still handed to MetricFlow, whose SQL client factory does not know that dialect — hence `Got dialect 'hologres'`.

## Change

- `dict_config_handler.py`: `DIALECT_MAPPING["hologres"] = "postgresql"` and `DEFAULT_SCHEMA_MAPPING["hologres"] = "public"`. Only MetricFlow's execution dialect is translated — Datus configs keep `type: hologres`, so the Hologres datasource adapter and its capability declarations stay in effect.
- `datus_config_handler.py`: this is the agent.yml path, and it carried a **second, inlined copy** of the same dialect table — mapping only in `dict_config_handler` would have left `--datasource` / `DatusConfigHandler` still failing. It now reuses `DIALECT_MAPPING` (no import cycle), and `hologres` was added to the `public`-default schema branch.
- `README-DATUS.md`: added a Hologres row. Also corrected PostgreSQL from `⚠️ Config only / Client not in this build` — that is stale (`PostgresSqlClient` is in the build and wired up at `sql_utils.py:151`), and leaving it would contradict the new Hologres row.

## Tests

`test_dict_config_handler.py` — 6 new cases: dialect mapping with host/port/database/username/`sslmode` preserved verbatim, explicit schema winning over the `public` default, case-insensitive `Hologres`, the raw-datasource path, and the `DatusConfigHandler` agent.yml path.

`test/sql_clients/test_hologres_dialect.py` (new) — covers the "ends up on the PostgreSQL client" acceptance criterion, with connections mocked:
- asserts the exact URL `postgresql://holo_user@holo-host:80/njyh?sslmode=require`
- no `sslmode` suffix when unset
- one unpatched `isinstance(client, PostgresSqlClient)` (SQLAlchemy engines are lazy, so no connection is made; guarded by `importorskip("psycopg2")`)

`test_dict_config_handler.py` + `test/sql_clients/` + `test/cli/`: 114 passed, 3 skipped. pre-commit black/flake8/mypy pass.

## Follow-up

Once this is released, `datus-semantic-metricflow` raises its dependency floor to the released version and adds an OSI regression test asserting a `type=hologres` live executor selects the PostgreSQL client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added full Hologres database support.
  - Hologres connections now use the PostgreSQL client and dialect.
  - Added default schema handling for Hologres.
  - PostgreSQL is now listed as fully supported.

- **Bug Fixes**
  - Improved Hologres configuration, including SSL settings, ports, and case-insensitive database type handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->